### PR TITLE
Add Unique loadBalancer Name

### DIFF
--- a/cloud/services/service/mock_service/loadbalancer_mock.go
+++ b/cloud/services/service/mock_service/loadbalancer_mock.go
@@ -80,6 +80,20 @@ func (mr *MockOscLoadBalancerInterfaceMockRecorder) CreateLoadBalancer(spec, sub
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLoadBalancer", reflect.TypeOf((*MockOscLoadBalancerInterface)(nil).CreateLoadBalancer), spec, subnetId, securityGroupId)
 }
 
+// CreateLoadBalancerTag mocks base method.
+func (m *MockOscLoadBalancerInterface) CreateLoadBalancerTag(spec *v1beta1.OscLoadBalancer, loadBalancerTag osc.ResourceTag) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateLoadBalancerTag", spec, loadBalancerTag)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateLoadBalancerTag indicates an expected call of CreateLoadBalancerTag.
+func (mr *MockOscLoadBalancerInterfaceMockRecorder) CreateLoadBalancerTag(spec, loadBalancerTag interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLoadBalancerTag", reflect.TypeOf((*MockOscLoadBalancerInterface)(nil).CreateLoadBalancerTag), spec, loadBalancerTag)
+}
+
 // DeleteLoadBalancer mocks base method.
 func (m *MockOscLoadBalancerInterface) DeleteLoadBalancer(spec *v1beta1.OscLoadBalancer) error {
 	m.ctrl.T.Helper()
@@ -92,6 +106,20 @@ func (m *MockOscLoadBalancerInterface) DeleteLoadBalancer(spec *v1beta1.OscLoadB
 func (mr *MockOscLoadBalancerInterfaceMockRecorder) DeleteLoadBalancer(spec interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLoadBalancer", reflect.TypeOf((*MockOscLoadBalancerInterface)(nil).DeleteLoadBalancer), spec)
+}
+
+// DeleteLoadBalancerTag mocks base method.
+func (m *MockOscLoadBalancerInterface) DeleteLoadBalancerTag(spec *v1beta1.OscLoadBalancer, loadBalancerTag osc.ResourceLoadBalancerTag) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteLoadBalancerTag", spec, loadBalancerTag)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteLoadBalancerTag indicates an expected call of DeleteLoadBalancerTag.
+func (mr *MockOscLoadBalancerInterfaceMockRecorder) DeleteLoadBalancerTag(spec, loadBalancerTag interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLoadBalancerTag", reflect.TypeOf((*MockOscLoadBalancerInterface)(nil).DeleteLoadBalancerTag), spec, loadBalancerTag)
 }
 
 // GetLoadBalancer mocks base method.
@@ -107,6 +135,21 @@ func (m *MockOscLoadBalancerInterface) GetLoadBalancer(spec *v1beta1.OscLoadBala
 func (mr *MockOscLoadBalancerInterfaceMockRecorder) GetLoadBalancer(spec interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLoadBalancer", reflect.TypeOf((*MockOscLoadBalancerInterface)(nil).GetLoadBalancer), spec)
+}
+
+// GetLoadBalancerTag mocks base method.
+func (m *MockOscLoadBalancerInterface) GetLoadBalancerTag(spec *v1beta1.OscLoadBalancer) (*osc.LoadBalancerTag, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLoadBalancerTag", spec)
+	ret0, _ := ret[0].(*osc.LoadBalancerTag)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLoadBalancerTag indicates an expected call of GetLoadBalancerTag.
+func (mr *MockOscLoadBalancerInterfaceMockRecorder) GetLoadBalancerTag(spec interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLoadBalancerTag", reflect.TypeOf((*MockOscLoadBalancerInterface)(nil).GetLoadBalancerTag), spec)
 }
 
 // LinkLoadBalancerBackendMachines mocks base method.

--- a/controllers/osccluster_loadbalancer_controller.go
+++ b/controllers/osccluster_loadbalancer_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	infrastructurev1beta1 "github.com/outscale-dev/cluster-api-provider-outscale.git/api/v1beta1"
+	osc "github.com/outscale/osc-sdk-go/v2"
 
 	"github.com/outscale-dev/cluster-api-provider-outscale.git/cloud/scope"
 	"github.com/outscale-dev/cluster-api-provider-outscale.git/cloud/services/security"
@@ -170,6 +171,27 @@ func reconcileLoadBalancer(ctx context.Context, clusterScope *scope.ClusterScope
 	if err != nil {
 		return reconcile.Result{}, err
 	}
+	name := loadBalancerName + "-" + clusterScope.GetUID()
+	nameTag := osc.ResourceTag{
+		Key:   "Name",
+		Value: name,
+	}
+	if loadbalancer != nil {
+		loadBalancerTag, err := loadBalancerSvc.GetLoadBalancerTag(loadBalancerSpec)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		if loadBalancerTag == nil && *loadbalancer.LoadBalancerName == loadBalancerName {
+			clusterScope.V(4).Info("LoadBalancer already exists", "loadBalancer", loadBalancerName)
+			return reconcile.Result{}, fmt.Errorf("A LoadBalancer %s already exists", loadBalancerName)
+		}
+		if loadBalancerTag != nil && *loadBalancerTag.Key == nameTag.Key && *loadBalancerTag.Value != nameTag.Value {
+			clusterScope.V(4).Info("LoadBalancer already exists by other cluster", "loadBalancer", loadBalancerName)
+
+			return reconcile.Result{}, fmt.Errorf("A LoadBalancer %s already exists that is used by another cluster other than %s", loadBalancerName, clusterScope.GetUID())
+		}
+	}
+
 	if loadbalancer == nil {
 		clusterScope.V(2).Info("Create the desired loadBalancer", "loadBalancerName", loadBalancerName)
 		_, err := loadBalancerSvc.CreateLoadBalancer(loadBalancerSpec, subnetId, securityGroupId)
@@ -186,6 +208,11 @@ func reconcileLoadBalancer(ctx context.Context, clusterScope *scope.ClusterScope
 		clusterScope.V(4).Info("Get loadbalancer", "loadbalancer", loadbalancer)
 		if err != nil {
 			return reconcile.Result{}, fmt.Errorf("%w Can not configure healthcheck for Osccluster %s/%s", err, clusterScope.GetNamespace(), clusterScope.GetName())
+		}
+		err = loadBalancerSvc.CreateLoadBalancerTag(loadBalancerSpec, nameTag)
+		clusterScope.V(2).Info("Create the desired loadBalancer tag name", "loadBalancerName", loadBalancerName)
+		if err != nil {
+			return reconcile.Result{}, fmt.Errorf("%w Can not tag loadBalancer for OscCluster %s/%s", err, clusterScope.GetNamespace(), clusterScope.GetName())
 		}
 	}
 	controlPlaneEndpoint := *loadbalancer.DnsName
@@ -218,11 +245,34 @@ func reconcileDeleteLoadBalancer(ctx context.Context, clusterScope *scope.Cluste
 		controllerutil.RemoveFinalizer(osccluster, "oscclusters.infrastructure.cluster.x-k8s.io")
 		return reconcile.Result{}, nil
 	}
+	name := loadBalancerName + "-" + clusterScope.GetUID()
+	nameTag := osc.ResourceTag{
+		Key:   "Name",
+		Value: name,
+	}
+	clusterScope.V(4).Info("Delete the desired loadBalancer", "loadBalancerName", loadBalancerName)
+	loadBalancerTag, err := loadBalancerSvc.GetLoadBalancerTag(loadBalancerSpec)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if loadBalancerTag != nil && *loadBalancerTag.Key == nameTag.Key && *loadBalancerTag.Value != nameTag.Value {
+		clusterScope.V(4).Info("Can not delete LoadBalancer that already exists by other cluster", "loadBalancer", loadBalancerName)
+		return reconcile.Result{}, nil
+	}
+
 	err = loadBalancerSvc.CheckLoadBalancerDeregisterVm(20, 120, loadBalancerSpec)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("%w VmBackend is not deregister in loadBalancer %s for OscCluster %s/%s", err, loadBalancerSpec.LoadBalancerName, clusterScope.GetNamespace(), clusterScope.GetName())
 	}
-	clusterScope.V(4).Info("Delete the desired loadBalancer", "loadBalancerName", loadBalancerName)
+
+	loadBalancerTagKey := osc.ResourceLoadBalancerTag{
+		Key: &nameTag.Key,
+	}
+	err = loadBalancerSvc.DeleteLoadBalancerTag(loadBalancerSpec, loadBalancerTagKey)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("%w Can not delete loadBalancer Tag for OscCluster %s/%s", err, clusterScope.GetNamespace(), clusterScope.GetName())
+	}
+
 	err = loadBalancerSvc.DeleteLoadBalancer(loadBalancerSpec)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("%w Can not delete loadBalancer for Osccluster %s/%s", err, clusterScope.GetNamespace(), clusterScope.GetName())


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->

**What type of PR is this?**
/kind feature 
<!--
Add one of the following kinds:
/kind feature           New functionality with test.
/kind bug               Fixes a newly discovered bug.
/kind api-change        Adds, removes, or changes an API
/kind cleanup           Adding tests, refactoring, fixing old bugs.
/kind deprecation       Related to a feature/enhancement marked for deprecation.
/kind regression        Related to a regression.
/kind documentation     Adds documentation.
/kind other             Related to updating dependencies, minor changes or other.
-->

**What this PR does / why we need it**:
Not having two cluster with the same loadBalancer Name.
Closes #230 
**Which issue(s) this PR fixes** :
Fixes #230 

**Special notes for your reviewer**:


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
