### PR TITLE
Kubernetes change rpm and deb repo

### DIFF
--- a/hack/json-format/run-integration-test.sh
+++ b/hack/json-format/run-integration-test.sh
@@ -50,13 +50,13 @@ function check_content() {
 	echo "$kubernetes_rpm_version"
 	kubernetes_semver=$(jq .kubernetes_semver "$ROOT"/"$check_output")
 	kubernetes_series=$(jq .kubernetes_series "$ROOT"/"$check_output")
-	if [[ $kubernetes_deb_version == '"1.22.1-00"' ]]; then
+	if [[ $kubernetes_deb_version == '"1.22.1-1.1"' ]]; then
 		echo "Find kubernetes_deb_version"
 	else
 		echo "Can not find kubernetes_deb_version"
 		exit 1
 	fi
-	if [[ $kubernetes_rpm_version == '"1.22.1-0"' ]]; then	
+	if [[ $kubernetes_rpm_version == '"1.22.1"' ]]; then	
 		echo "Find kubernetes_rpm_version"
 	else	
 		echo "Can not find kubernetes_rpm_version"

--- a/hack/json-format/src/core.rs
+++ b/hack/json-format/src/core.rs
@@ -35,9 +35,9 @@ impl DataTrait for KubernetesImage {
                 .as_deref()
                 .unwrap_or("v1.22.1"),
         );
-        let kubernetes_deb_version = String::from(&kubernetes_version.replace("v", "")) + "-00";
+        let kubernetes_deb_version = String::from(&kubernetes_version.replace("v", "")) + "-1.1";
         self.kubernetes_deb_version = Some(kubernetes_deb_version);
-        let kubernetes_rpm_version = String::from(&kubernetes_version.replace("v", "")) + "-0";
+        let kubernetes_rpm_version = String::from(&kubernetes_version.replace("v", ""));
         self.kubernetes_rpm_version = Some(kubernetes_rpm_version);
         println!(
             "kubernetes json build timestamp: {}",
@@ -67,14 +67,14 @@ impl DataTrait for KubernetesImage {
             self.kubernetes_rpm_version
                 .to_owned()
                 .as_deref()
-                .unwrap_or("1.22.1-00")
+                .unwrap_or("1.22.1-1.1")
         );
         println!(
             "kubernetes deb version: {:?}",
             self.kubernetes_deb_version
                 .to_owned()
                 .as_deref()
-                .unwrap_or("1.22.1-0")
+                .unwrap_or("1.22.1")
         );
         Ok(())
     }
@@ -153,7 +153,7 @@ mod datas_test {
             println!("value: {:#?}", kubernetes);
             assert_eq!(
                 kubernetes.kubernetes_rpm_version,
-                Some("1.22.1-0".to_string())
+                Some("1.22.1".to_string())
             )
         }
     }

--- a/hack/json-format/tests/integration_test.rs
+++ b/hack/json-format/tests/integration_test.rs
@@ -7,5 +7,5 @@ fn success() {
     let kubernetes_version = create_kubernetes_json();
     let mut kubernetes_image = kubernetes_version.kubernetes_output;
     let _ = kubernetes_image.drain(1..32);
-    assert_eq!(kubernetes_image, "{\"kubernetes_deb_version\":\"1.22.1-00\",\"kubernetes_rpm_version\":\"1.22.1-0\",\"kubernetes_semver\":\"v1.22.1\",\"kubernetes_series\":\"v1.22\"}");
+    assert_eq!(kubernetes_image, "{\"kubernetes_deb_version\":\"1.22.1-1.1\",\"kubernetes_rpm_version\":\"1.22.1\",\"kubernetes_semver\":\"v1.22.1\",\"kubernetes_series\":\"v1.22\"}");
 }


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->

**What type of PR is this?**
/kind api-change 
<!--
Add one of the following kinds:
/kind feature           New functionality with test.
/kind bug               Fixes a newly discovered bug.
/kind api-change        Adds, removes, or changes an API
/kind cleanup           Adding tests, refactoring, fixing old bugs.
/kind deprecation       Related to a feature/enhancement marked for deprecation.
/kind regression        Related to a regression.
/kind documentation     Adds documentation.
/kind other             Related to updating dependencies, minor changes or other.
-->

**What this PR does / why we need it**:
Kubernetes change repo for artefact. (https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/) The repo change in image-builder but not the version format.
(https://github.com/kubernetes-sigs/image-builder/commit/5761d5e6026938a71584c7c2672ae718436f211d)



