### PR TITLE
Check keypair name is the same in vm and keypair section

### DIFF
--- a/controllers/oscmachine_controller.go
+++ b/controllers/oscmachine_controller.go
@@ -252,6 +252,11 @@ func (r *OscMachineReconciler) reconcile(ctx context.Context, machineScope *scop
 		}
 	}
 
+	checkKeypairSameNameErr := checkKeypairSameName(machineScope)
+	if checkKeypairSameNameErr != nil {
+		return reconcile.Result{}, checkKeypairSameNameErr
+	}
+
 	checkOscAssociateVmSecurityGroupErr := checkVmSecurityGroupOscAssociateResourceName(machineScope, clusterScope)
 	if checkOscAssociateVmSecurityGroupErr != nil {
 		return reconcile.Result{}, checkOscAssociateVmSecurityGroupErr

--- a/controllers/oscmachine_keypair_controller.go
+++ b/controllers/oscmachine_keypair_controller.go
@@ -51,6 +51,27 @@ func checkKeypairFormatParameters(machineScope *scope.MachineScope) (string, err
 	return "", nil
 }
 
+// checkKeypairSameName check that keypair name is the same in vm and keypair section
+func checkKeypairSameName(machineScope *scope.MachineScope) error {
+	var keypairSpec *infrastructurev1beta1.OscKeypair
+	nodeSpec := machineScope.GetNode()
+	if nodeSpec.KeyPair.Name == "" {
+		nodeSpec.SetKeyPairDefaultValue()
+		keypairSpec = &nodeSpec.KeyPair
+	} else {
+		keypairSpec = machineScope.GetKeypair()
+	}
+	keypairName := keypairSpec.Name
+	vmSpec := machineScope.GetVm()
+	vmSpec.SetDefaultValue()
+	machineScope.V(2).Info("Check keypair name is the same in vm and keypair section ")
+	vmKeypairName := vmSpec.KeypairName
+	if keypairName != vmKeypairName {
+		return fmt.Errorf("%s is not the same in vm and keypair section", keypairName)
+	}
+	return nil
+}
+
 // getKeyPairResourceId return the keypairName from the resourceMap base on resourceName (tag name + cluster uid)
 func getKeyPairResourceId(resourceName string, machineScope *scope.MachineScope) (string, error) {
 	keypairRef := machineScope.GetKeypairRef()


### PR DESCRIPTION
**What type of PR is this?**

/kind bug   


**What this PR does / why we need it**:

Check keypair name is the same in vm and keypair section

**Which issue(s) this PR fixes**:
Fixes #312 
Closes #312 

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
