### PR TITLE
fix(publicips): not delete when resourceId provided on the spec

### DIFF
--- a/controllers/osccluster_publicip_controller.go
+++ b/controllers/osccluster_publicip_controller.go
@@ -152,13 +152,11 @@ func reconcilePublicIp(ctx context.Context, clusterScope *scope.ClusterScope, pu
 			publicIpRef.ResourceMap = make(map[string]string)
 		}
 		if publicIpSpec.ResourceId != "" {
-			publicIpRef.ResourceMap[publicIpName] = publicIpSpec.ResourceId
+			// check if IP exist
+			_, err = publicIpSvc.GetPublicIp(publicIpSpec.ResourceId)
+			return reconcile.Result{}, err
 		}
-		_, resourceMapExist := publicIpRef.ResourceMap[publicIpName]
-		if resourceMapExist {
-			publicIpSpec.ResourceId = publicIpRef.ResourceMap[publicIpName]
-		}
-
+		publicIpRef.ResourceMap[publicIpName] = publicIpSpec.ResourceId
 		publicIpId := publicIpRef.ResourceMap[publicIpName]
 		if !Contains(validPublicIpIds, publicIpId) && tag == nil {
 			publicIp, err := publicIpSvc.CreatePublicIp(publicIpName)

--- a/controllers/oscmachine_volume_controller_unit_test.go
+++ b/controllers/oscmachine_volume_controller_unit_test.go
@@ -405,6 +405,8 @@ func TestReconcileVolumeResourceId(t *testing.T) {
 			publicIpRef.ResourceMap = make(map[string]string)
 			if vtc.expPublicIpFound {
 				publicIpRef.ResourceMap[publicIpName] = publicIpId
+			} else {
+				mockOscPublicIpInterface.EXPECT().GetPublicIp(gomock.Eq(publicIpId))
 			}
 
 			linkPublicIpId := "eipassoc-" + publicIpName


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature           New functionality with test.
/kind bug               Fixes a newly discovered bug.
/kind api-change        Adds, removes, or changes an API
/kind cleanup           Adding tests, refactoring, fixing old bugs.
/kind deprecation       Related to a feature/enhancement marked for deprecation.
/kind regression        Related to a regression.
/kind documentation     Adds documentation.
/kind other             Related to updating dependencies, minor changes or other.
-->
/kind bug               Fixes a publicIp deletion to delete on publicIps created by capo


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**
Fixes #358

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
