### PR TITLE
docs: Add example for Cluster API with MetalLB integration

### DIFF
--- a/example/metalLb/Readme.md
+++ b/example/metalLb/Readme.md
@@ -1,0 +1,63 @@
+# Kubernetes Cluster Deployment with MetalLB
+
+## Prerequisites
+Before starting, ensure the following are in place:
+
+1. Infrastructure
+Management Cluster:
+- A management cluster is required to use Cluster API for provisioning and managing the workload cluster. This cluster can be deployed locally (e.g., using kind or minikube) or [rke.](https://github.com/outscale/osc-k8s-rke-cluster)
+
+2. Tools
+- kubectl
+- Cluster API
+- Cluster-api outscale provider 
+
+3. MetalLB
+Ensure Layer 2 (L2) connectivity between your cluster nodes to support MetalLB's ARP-based IP advertising.
+IP range configured for MetalLB should not overlap with any existing subnet or DHCP ranges in your environment.
+
+## This documentation provides a step-by-step guide to:
+
+- Deploy a Kubernetes cluster with Cluster API.
+- Install and configure MetalLB.
+- Test the setup with a LoadBalancer service.
+- Verify the assigned IP from the MetalLB IP pool.
+
+### MetalLB Integration in the Control Plane
+
+The MetalLB installation is fully automated through the postKubeadmCommands in the control plane configuration.
+The IP pool (10.0.1.240-10.0.1.250) and Layer 2 advertisement configuration are pre-created as a file and applied during the node initialization.
+After deployment, verify the metallb-system namespace and pods, then test by deploying a LoadBalancer service.
+
+```bash
+kubectl apply -f example/metalLb/service.yaml
+```
+
+```bash
+kubectl get pods -n metallb-system
+```
+
+```bash
+NAME                          READY   STATUS    RESTARTS   AGE
+controller-7bcd9b5f47-l9r96   1/1     Running   0          104s
+speaker-5dvs2                 1/1     Running   0          104s
+speaker-nnwdg                 1/1     Running   0          104s
+speaker-rvkmp                 1/1     Running   0          104s
+```
+
+### Deploy a Test Service
+```bash
+kubectl apply -f service.yaml
+```
+
+```bash
+kubectl get svc nginx-service
+NAME            TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)        AGE
+nginx-service   LoadBalancer   10.43.209.200   10.0.1.244    80:30509/TCP   6m45s
+```
+
+#### Test the Service
+Access the service using the external IP:
+```bash
+curl http://10.0.1.244
+```

--- a/example/metalLb/metalLb.yaml
+++ b/example/metalLb/metalLb.yaml
@@ -1,0 +1,211 @@
+# Cluster Configuration
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: hello-osc
+  namespace: default
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 10.42.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: hello-osc-control-plane
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: OscCluster
+    name: hello-osc
+---
+# Outscale Cluster Infrastructure
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OscCluster
+metadata:
+  name: hello-osc
+  namespace: default
+spec:
+  network:
+    clusterName: hello-osc
+    subregionName: eu-west-2a
+    internetService:
+      clusterName: hello-osc
+    loadBalancer:
+      clusterName: hello-osc
+      loadbalancername: hello-osc-k8s
+    natService:
+      clusterName: hello-osc
+    net:
+      clusterName: hello-osc
+---
+# Control Plane Configuration
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: hello-osc-control-plane
+  namespace: default
+spec:
+  kubeadmConfigSpec:
+    files:
+      - content: |
+          #!/bin/sh
+
+          # Installer une version mise à jour de runc
+          curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
+          chmod +x /tmp/runc.amd64
+          cp -f /tmp/runc.amd64 /usr/local/sbin/runc
+
+          # Configurer MetalLB
+          cat <<EOF > /tmp/metallb-config.yaml
+          apiVersion: metallb.io/v1beta1
+          kind: IPAddressPool
+          metadata:
+            name: metallb-pool
+            namespace: metallb-system
+          spec:
+            addresses:
+            - 10.0.1.240-10.0.1.250
+          ---
+          apiVersion: metallb.io/v1beta1
+          kind: L2Advertisement
+          metadata:
+            name: l2-advertisement
+            namespace: metallb-system
+          spec: {}
+          EOF
+        owner: root:root
+        path: /tmp/set_runc_and_metallb.sh
+        permissions: "0744"
+    initConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          cloud-provider: external
+          provider-id: aws://'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
+        name: '{{ ds.meta_data.local_hostname }}'
+    joinConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          cloud-provider: external
+          provider-id: aws://'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
+    preKubeadmCommands:
+      - sh /tmp/set_runc_and_metallb.sh
+    postKubeadmCommands:
+      - kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/main/config/manifests/metallb-native.yaml
+      - kubectl create namespace metallb-system || true
+      - kubectl apply -f /tmp/metallb-config.yaml
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: OscMachineTemplate
+      name: hello-osc-control-plane
+  replicas: 1
+  version: v1.28.5
+---
+# Worker Nodes Configuration
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: hello-osc-md-0
+  namespace: default
+spec:
+  clusterName: hello-osc
+  replicas: 1
+  selector:
+    matchLabels: null
+  template:
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: hello-osc-md-0
+      clusterName: hello-osc
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: OscMachineTemplate
+        name: hello-osc-md-0
+      version: v1.28.5
+---
+# Worker Nodes Template
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: hello-osc-md-0
+  namespace: default
+spec:
+  template:
+    spec:
+      files:
+        - content: |
+            #!/bin/sh
+
+            # Installer une version mise à jour de runc
+            curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
+            chmod +x /tmp/runc.amd64
+            cp -f /tmp/runc.amd64 /usr/local/sbin/runc
+          owner: root:root
+          path: /tmp/set_runc.sh
+          permissions: "0744"
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            cloud-provider: external
+            provider-id: aws://'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
+          name: '{{ ds.meta_data.local_hostname }}'
+      preKubeadmCommands:
+        - sh /tmp/set_runc.sh
+---
+# Outscale Machine Template for Control Plane
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OscMachineTemplate
+metadata:
+  name: hello-osc-control-plane-v2
+  namespace: default
+spec:
+  template:
+    spec:
+      node:
+        clusterName: hello-osc
+        image:
+          name: ubuntu-2004-2004-kubernetes-v1.28.5-2022-08-22
+        keypair:
+          name: cluster-api-test
+        vm:
+          clusterName: hello-osc
+          keypairName: cluster-api-test
+          loadBalancerName: hello-osc-k8s
+          role: controlplane
+          rootDisk:
+            rootDiskIops: 2000
+            rootDiskSize: 20
+            rootDiskType: io1
+          subregionName: eu-west-2a
+          vmType: tinav6.c4r8p1
+---
+# Outscale Machine Template for Workers
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OscMachineTemplate
+metadata:
+  name: hello-osc-md-0-v2
+  namespace: default
+spec:
+  template:
+    spec:
+      node:
+        clusterName: hello-osc
+        image:
+          name: ubuntu-2004-2004-kubernetes-v1.28.5-2022-08-22
+        keypair:
+          name: cluster-api-test
+        vm:
+          clusterName: hello-osc
+          keypairName: cluster-api-test
+          rootDisk:
+            rootDiskIops: 2000
+            rootDiskSize: 20
+            rootDiskType: io1
+          subregionName: eu-west-2a
+          vmType: tinav6.c4r8p1

--- a/example/metalLb/service.yaml
+++ b/example/metalLb/service.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+spec:
+  selector:
+    app: nginx
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:latest
+          ports:
+            - containerPort: 80


### PR DESCRIPTION
This PR is about : 
- Adding an example configuration for deploying a Kubernetes cluster using Cluster API.
- Including MetalLB setup and configuration instructions.
- Documenting steps to deploy a LoadBalancer service with MetalLB.
