### PR TITLE
feat(security-groups): Allow list of CIDRs for ipRange

### DIFF
--- a/cloud/services/security/securitygroup.go
+++ b/cloud/services/security/securitygroup.go
@@ -19,6 +19,7 @@ package security
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"errors"
 
@@ -135,9 +136,10 @@ func (s *Service) CreateSecurityGroupRule(securityGroupId string, flow string, i
 	} else if securityGroupMemberId != "" && ipRange != "" {
 		return nil, errors.New("Get Both ipRange and securityGroupMemberId")
 	} else {
+		ipRanges := strings.Split(ipRange, ",")
 		rule = osc.SecurityGroupRule{
 			IpProtocol:    &ipProtocol,
-			IpRanges:      &[]string{ipRange},
+			IpRanges:      &ipRanges,
 			FromPortRange: &fromPortRange,
 			ToPortRange:   &toPortRange,
 		}
@@ -202,9 +204,10 @@ func (s *Service) DeleteSecurityGroupRule(securityGroupId string, flow string, i
 			ToPortRange:           &toPortRange,
 		}
 	} else {
+		ipRanges := strings.Split(ipRange, ",")
 		rule = osc.SecurityGroupRule{
 			IpProtocol:    &ipProtocol,
-			IpRanges:      &[]string{ipRange},
+			IpRanges:      &ipRanges,
 			FromPortRange: &fromPortRange,
 			ToPortRange:   &toPortRange,
 		}


### PR DESCRIPTION
This PR adds the feature where you can also specify a comma seperated list of CIDR's in the security group rule ipRange field to create a rule for multiple cidrs.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
