### PR TITLE
Rework reconcileVm and reconcileBastion

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -378,22 +378,21 @@ type OscVm struct {
 }
 
 type OscBastion struct {
-	Name                     string                    `json:"name,omitempty"`
-	ImageId                  string                    `json:"imageId,omitempty"`
-	ImageName                string                    `json:"imageName,omitempty"`
-	KeypairName              string                    `json:"keypairName,omitempty"`
-	VmType                   string                    `json:"vmType,omitempty"`
-	DeviceName               string                    `json:"deviceName,omitempty"`
-	SubnetName               string                    `json:"subnetName,omitempty"`
-	RootDisk                 OscRootDisk               `json:"rootDisk,omitempty"`
-	PublicIpName             string                    `json:"publicIpName,omitempty"`
-	SubregionName            string                    `json:"subregionName,omitempty"`
-	PrivateIps               []OscPrivateIpElement     `json:"privateIps,omitempty"`
-	SecurityGroupNames       []OscSecurityGroupElement `json:"securityGroupNames,omitempty"`
-	ResourceId               string                    `json:"resourceId,omitempty"`
-	ClusterName              string                    `json:"clusterName,omitempty"`
-	Enable                   bool                      `json:"enable,omitempty"`
-	PublicIpNameAfterBastion bool                      `json:"publicIpNameAfterBastion,omitempty"`
+	Name               string                    `json:"name,omitempty"`
+	ImageId            string                    `json:"imageId,omitempty"`
+	ImageName          string                    `json:"imageName,omitempty"`
+	KeypairName        string                    `json:"keypairName,omitempty"`
+	VmType             string                    `json:"vmType,omitempty"`
+	DeviceName         string                    `json:"deviceName,omitempty"`
+	SubnetName         string                    `json:"subnetName,omitempty"`
+	RootDisk           OscRootDisk               `json:"rootDisk,omitempty"`
+	PublicIpName       string                    `json:"publicIpName,omitempty"`
+	SubregionName      string                    `json:"subregionName,omitempty"`
+	PrivateIps         []OscPrivateIpElement     `json:"privateIps,omitempty"`
+	SecurityGroupNames []OscSecurityGroupElement `json:"securityGroupNames,omitempty"`
+	ResourceId         string                    `json:"resourceId,omitempty"`
+	ClusterName        string                    `json:"clusterName,omitempty"`
+	Enable             bool                      `json:"enable,omitempty"`
 }
 
 type OscRootDisk struct {

--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -190,16 +190,6 @@ func (s *ClusterScope) SetExtraSecurityGroupRule(extraSecurityGroupRule bool) {
 	s.OscCluster.Spec.Network.ExtraSecurityGroupRule = extraSecurityGroupRule
 }
 
-// GetPublicIpNameAfterBastion return publicIpNameAfterBastion
-func (s *ClusterScope) GetPublicIpNameAfterBastion() bool {
-	return s.OscCluster.Spec.Network.Bastion.PublicIpNameAfterBastion
-}
-
-// SetPublicIpNameAfterBastion set the publicIpNameAfterBastion
-func (s *ClusterScope) SetPublicIpNameAfterBastion(publicIpNameAfterBastion bool) {
-	s.OscCluster.Spec.Network.Bastion.PublicIpNameAfterBastion = publicIpNameAfterBastion
-}
-
 // GetNetwork return the network of the cluster
 func (s *ClusterScope) GetNetwork() *infrastructurev1beta1.OscNetwork {
 	return &s.OscCluster.Spec.Network
@@ -336,6 +326,11 @@ func (s *ClusterScope) GetControlPlaneEndpointPort() int32 {
 	return s.OscCluster.Spec.ControlPlaneEndpoint.Port
 }
 
+// GetReady get ready status
+func (s *ClusterScope) GetReady() bool {
+	return s.OscCluster.Status.Ready
+}
+
 // SetNotReady set not ready status
 func (s *ClusterScope) SetNotReady() {
 	s.OscCluster.Status.Ready = false
@@ -384,6 +379,11 @@ func (s *ClusterScope) GetImage() *infrastructurev1beta1.OscImage {
 // SetVmState set vmstate
 func (s *ClusterScope) SetVmState(v infrastructurev1beta1.VmState) {
 	s.OscCluster.Status.VmState = &v
+}
+
+// SetVmState set vmstate
+func (s *ClusterScope) GetVmState() *infrastructurev1beta1.VmState {
+	return s.OscCluster.Status.VmState
 }
 
 // PatchObject keep the cluster configuration and status

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -273,6 +273,11 @@ func (m *MachineScope) SetProviderID(subregionName string, vmId string) {
 	m.OscMachine.Spec.ProviderID = pointer.StringPtr(pid)
 }
 
+// SetVmID set the instanceID
+func (m *MachineScope) SetVmID(vmId string) {
+	m.OscMachine.Spec.Node.Vm.ResourceId = vmId
+}
+
 // GetVmState return the vmState
 func (m *MachineScope) GetVmState() *infrastructurev1beta1.VmState {
 	return m.OscMachine.Status.VmState

--- a/cloud/services/compute/mock_compute/vm_mock.go
+++ b/cloud/services/compute/mock_compute/vm_mock.go
@@ -6,7 +6,6 @@ package mock_compute
 
 import (
 	reflect "reflect"
-	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 	v1beta1 "github.com/outscale-dev/cluster-api-provider-outscale.git/api/v1beta1"
@@ -50,20 +49,6 @@ func (m *MockOscVmInterface) AddCcmTag(clusterName, hostname, vmId string) error
 func (mr *MockOscVmInterfaceMockRecorder) AddCcmTag(clusterName, hostname, vmId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddCcmTag", reflect.TypeOf((*MockOscVmInterface)(nil).AddCcmTag), clusterName, hostname, vmId)
-}
-
-// CheckVmState mocks base method.
-func (m *MockOscVmInterface) CheckVmState(clockInsideLoop, clockLoop time.Duration, state, vmId string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckVmState", clockInsideLoop, clockLoop, state, vmId)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CheckVmState indicates an expected call of CheckVmState.
-func (mr *MockOscVmInterfaceMockRecorder) CheckVmState(clockInsideLoop, clockLoop, state, vmId interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckVmState", reflect.TypeOf((*MockOscVmInterface)(nil).CheckVmState), clockInsideLoop, clockLoop, state, vmId)
 }
 
 // CreateVm mocks base method.
@@ -123,6 +108,15 @@ func (m *MockOscVmInterface) GetCapacity(tagKey, tagValue, vmType string) (v1.Re
 func (mr *MockOscVmInterfaceMockRecorder) GetCapacity(tagKey, tagValue, vmType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCapacity", reflect.TypeOf((*MockOscVmInterface)(nil).GetCapacity), tagKey, tagValue, vmType)
+}
+
+// GetVmListFromTag mocks base method.
+func (m *MockOscVmInterface) GetVmListFromTag(tagKey string, tagValue string) ([]osc.Vm, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVmListFromTag", tagKey, tagValue)
+	ret0, _ := ret[0].([]osc.Vm)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetVm mocks base method.

--- a/cloud/services/compute/mock_compute/vm_mock.go
+++ b/cloud/services/compute/mock_compute/vm_mock.go
@@ -110,15 +110,6 @@ func (mr *MockOscVmInterfaceMockRecorder) GetCapacity(tagKey, tagValue, vmType i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCapacity", reflect.TypeOf((*MockOscVmInterface)(nil).GetCapacity), tagKey, tagValue, vmType)
 }
 
-// GetVmListFromTag mocks base method.
-func (m *MockOscVmInterface) GetVmListFromTag(tagKey string, tagValue string) ([]osc.Vm, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetVmListFromTag", tagKey, tagValue)
-	ret0, _ := ret[0].([]osc.Vm)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
 // GetVm mocks base method.
 func (m *MockOscVmInterface) GetVm(vmId string) (*osc.Vm, error) {
 	m.ctrl.T.Helper()
@@ -132,6 +123,21 @@ func (m *MockOscVmInterface) GetVm(vmId string) (*osc.Vm, error) {
 func (mr *MockOscVmInterfaceMockRecorder) GetVm(vmId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVm", reflect.TypeOf((*MockOscVmInterface)(nil).GetVm), vmId)
+}
+
+// GetVmListFromTag mocks base method.
+func (m *MockOscVmInterface) GetVmListFromTag(tagKey, tagName string) ([]osc.Vm, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVmListFromTag", tagKey, tagName)
+	ret0, _ := ret[0].([]osc.Vm)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVmListFromTag indicates an expected call of GetVmListFromTag.
+func (mr *MockOscVmInterfaceMockRecorder) GetVmListFromTag(tagKey, tagName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVmListFromTag", reflect.TypeOf((*MockOscVmInterface)(nil).GetVmListFromTag), tagKey, tagName)
 }
 
 // GetVmState mocks base method.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_oscclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_oscclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: oscclusters.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -85,8 +85,6 @@ spec:
                         type: array
                       publicIpName:
                         type: string
-                      publicIpNameAfterBastion:
-                        type: boolean
                       resourceId:
                         type: string
                       rootDisk:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_oscclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_oscclustertemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: oscclustertemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -49,12 +49,10 @@ spec:
                       ObjectMeta is metadata that all persisted resources must have, which includes all objects
                       users must create. This is a copy of customizable fields from metav1.ObjectMeta.
 
-
                       ObjectMeta is embedded in `Machine.Spec`, `MachineDeployment.Template` and `MachineSet.Template`,
                       which are not top-level Kubernetes objects. Given that metav1.ObjectMeta has lots of special cases
                       and read-only fields which end up in the generated CRD validation, having it as a subset simplifies
                       the API and some issues that can impact user experience.
-
 
                       During the [upgrade to controller-tools@v2](https://github.com/kubernetes-sigs/cluster-api/pull/1054)
                       for v1alpha2, we noticed a failure would occur running Cluster API test suite against the new CRDs,
@@ -62,12 +60,10 @@ spec:
                       The investigation showed that `controller-tools@v2` behaves differently than its previous version
                       when handling types from [metav1](k8s.io/apimachinery/pkg/apis/meta/v1) package.
 
-
                       In more details, we found that embedded (non-top level) types that embedded `metav1.ObjectMeta`
                       had validation properties, including for `creationTimestamp` (metav1.Time).
                       The `metav1.Time` type specifies a custom json marshaller that, when IsZero() is true, returns `null`
                       which breaks validation because the field isn't marked as nullable.
-
 
                       In future versions, controller-tools@v2 might allow overriding the type and validation for embedded
                       types. When that happens, this hack should be revisited.
@@ -141,8 +137,6 @@ spec:
                                 type: array
                               publicIpName:
                                 type: string
-                              publicIpNameAfterBastion:
-                                type: boolean
                               resourceId:
                                 type: string
                               rootDisk:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_oscmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_oscmachines.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: oscmachines.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_oscmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_oscmachinetemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: oscmachinetemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -50,12 +50,10 @@ spec:
                       ObjectMeta is metadata that all persisted resources must have, which includes all objects
                       users must create. This is a copy of customizable fields from metav1.ObjectMeta.
 
-
                       ObjectMeta is embedded in `Machine.Spec`, `MachineDeployment.Template` and `MachineSet.Template`,
                       which are not top-level Kubernetes objects. Given that metav1.ObjectMeta has lots of special cases
                       and read-only fields which end up in the generated CRD validation, having it as a subset simplifies
                       the API and some issues that can impact user experience.
-
 
                       During the [upgrade to controller-tools@v2](https://github.com/kubernetes-sigs/cluster-api/pull/1054)
                       for v1alpha2, we noticed a failure would occur running Cluster API test suite against the new CRDs,
@@ -63,12 +61,10 @@ spec:
                       The investigation showed that `controller-tools@v2` behaves differently than its previous version
                       when handling types from [metav1](k8s.io/apimachinery/pkg/apis/meta/v1) package.
 
-
                       In more details, we found that embedded (non-top level) types that embedded `metav1.ObjectMeta`
                       had validation properties, including for `creationTimestamp` (metav1.Time).
                       The `metav1.Time` type specifies a custom json marshaller that, when IsZero() is true, returns `null`
                       which breaks validation because the field isn't marked as nullable.
-
 
                       In future versions, controller-tools@v2 might allow overriding the type and validation for embedded
                       types. When that happens, this hack should be revisited.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -27,29 +27,8 @@ rules:
   - cluster.x-k8s.io
   resources:
   - clusters
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - cluster.x-k8s.io
-  resources:
   - clusters/status
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - cluster.x-k8s.io
-  resources:
   - machines
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - cluster.x-k8s.io
-  resources:
   - machines/status
   verbs:
   - get
@@ -59,57 +38,7 @@ rules:
   - infrastructure.cluster.x-k8s.io
   resources:
   - oscclusters
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - infrastructure.cluster.x-k8s.io
-  resources:
-  - oscclusters/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - infrastructure.cluster.x-k8s.io
-  resources:
-  - oscclusters/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - infrastructure.cluster.x-k8s.io
-  resources:
   - oscmachines
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - infrastructure.cluster.x-k8s.io
-  resources:
-  - oscmachines/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - infrastructure.cluster.x-k8s.io
-  resources:
-  - oscmachines/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - infrastructure.cluster.x-k8s.io
-  resources:
   - oscmachinetemplates
   verbs:
   - create
@@ -122,6 +51,15 @@ rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io
   resources:
+  - oscclusters/finalizers
+  - oscmachines/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - oscclusters/status
+  - oscmachines/status
   - oscmachinetemplates/status
   verbs:
   - get

--- a/controllers/osccluster_bastion_controller.go
+++ b/controllers/osccluster_bastion_controller.go
@@ -317,7 +317,7 @@ func reconcileBastion(ctx context.Context, clusterScope *scope.ClusterScope, vmS
 			clusterScope.V(4).Info("Bastion is running", "vmId", vmId)
 		}
 
-		if *bastionState == infrastructurev1beta1.VmStateRunning {
+		if bastionState != nil && *bastionState == infrastructurev1beta1.VmStateRunning {
 			vmId := bastionSpec.ResourceId
 
 			if bastionSpec.PublicIpName != "" && linkPublicIpRef.ResourceMap[bastionPublicIpName] == "" {
@@ -328,7 +328,10 @@ func reconcileBastion(ctx context.Context, clusterScope *scope.ClusterScope, vmS
 				clusterScope.V(4).Info("Get bastionPublicIpName", "bastionPublicIpName", bastionPublicIpName)
 				linkPublicIpRef.ResourceMap[bastionPublicIpName] = linkPublicIpId
 			}
+		} else {
+			clusterScope.V(4).Info("VM is not running, skipping public IP linking")
 		}
+
 	}
 	clusterScope.V(4).Info("Bastion is reconciled")
 	return reconcile.Result{}, nil

--- a/controllers/osccluster_bastion_controller_unit_test.go
+++ b/controllers/osccluster_bastion_controller_unit_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/golang/mock/gomock"
 	infrastructurev1beta1 "github.com/outscale-dev/cluster-api-provider-outscale.git/api/v1beta1"
@@ -165,85 +164,6 @@ var (
 				SubnetName:    "test-subnet",
 				VmType:        "tinav3.c2r4p2",
 				PublicIpName:  "test-publicip",
-				SecurityGroupNames: []infrastructurev1beta1.OscSecurityGroupElement{
-					{
-						Name: "test-securitygroup",
-					},
-				},
-				PrivateIps: []infrastructurev1beta1.OscPrivateIpElement{
-					{
-						Name:      "test-privateip",
-						PrivateIp: "10.0.0.17",
-					},
-				},
-			},
-		},
-	}
-
-	defaultPublicIpNameAfterBastionReconcile = infrastructurev1beta1.OscClusterSpec{
-		Network: infrastructurev1beta1.OscNetwork{
-			Net: infrastructurev1beta1.OscNet{
-				Name:        "test-net",
-				IpRange:     "10.0.0.0/16",
-				ClusterName: "test-cluster",
-				ResourceId:  "vpc-test-net-uid",
-			},
-			Subnets: []*infrastructurev1beta1.OscSubnet{
-				{
-					Name:          "test-subnet",
-					IpSubnetRange: "10.0.0.0/24",
-					SubregionName: "eu-west-2a",
-					ResourceId:    "subnet-test-subnet-uid",
-				},
-			},
-			SecurityGroups: []*infrastructurev1beta1.OscSecurityGroup{
-				{
-					Name:        "test-securitygroup",
-					Description: "test securitygroup",
-					ResourceId:  "sg-test-securitygroup-uid",
-					SecurityGroupRules: []infrastructurev1beta1.OscSecurityGroupRule{
-						{
-							Name:          "test-securitygrouprule",
-							Flow:          "Inbound",
-							IpProtocol:    "tcp",
-							IpRange:       "0.0.0.0/0",
-							FromPortRange: 6443,
-							ToPortRange:   6443,
-						},
-					},
-				},
-			},
-			LoadBalancer: infrastructurev1beta1.OscLoadBalancer{
-				LoadBalancerName:  "test-loadbalancer",
-				LoadBalancerType:  "internet-facing",
-				SubnetName:        "test-subnet",
-				SecurityGroupName: "test-securitygroup",
-			},
-			PublicIps: []*infrastructurev1beta1.OscPublicIp{
-				{
-					Name:       "test-publicip",
-					ResourceId: "test-publicip-uid",
-				},
-			},
-			Bastion: infrastructurev1beta1.OscBastion{
-				Enable:      true,
-				ClusterName: "test-cluster",
-				Name:        "test-bastion",
-				ImageId:     "ami-00000000",
-				DeviceName:  "/dev/xvdb",
-				KeypairName: "rke",
-				RootDisk: infrastructurev1beta1.OscRootDisk{
-
-					RootDiskSize: 30,
-					RootDiskIops: 1500,
-					RootDiskType: "io1",
-				},
-				SubregionName:            "eu-west-2a",
-				SubnetName:               "test-subnet",
-				VmType:                   "tinav3.c2r4p2",
-				ResourceId:               "i-test-bastion-uid",
-				PublicIpName:             "test-publicip",
-				PublicIpNameAfterBastion: true,
 				SecurityGroupNames: []infrastructurev1beta1.OscSecurityGroupElement{
 					{
 						Name: "test-securitygroup",
@@ -1835,7 +1755,6 @@ func TestReconcileBastion(t *testing.T) {
 			clusterScope, ctx, mockOscVmInterface, mockOscPublicIpInterface, mockOscSecurityGroupInterface, mockOscImageInterface, mockOscTagInterface := SetupWithBastionMock(t, btc.name, btc.clusterSpec)
 			bastionName := btc.clusterSpec.Network.Bastion.Name + "-uid"
 			vmId := "i-" + bastionName
-			vmState := "running"
 
 			subnetName := btc.clusterSpec.Network.Bastion.SubnetName + "-uid"
 			subnetId := "subnet-" + subnetName
@@ -1877,8 +1796,6 @@ func TestReconcileBastion(t *testing.T) {
 			}
 
 			bastionSpec := btc.clusterSpec.Network.Bastion
-			var clockInsideLoop time.Duration = 5
-			var firstClockLoop time.Duration = 120
 			createVms := osc.CreateVmsResponse{
 				Vms: &[]osc.Vm{
 					{
@@ -1918,24 +1835,12 @@ func TestReconcileBastion(t *testing.T) {
 					CreateVmUserData(gomock.Eq(""), gomock.Eq(&bastionSpec), gomock.Eq(subnetId), gomock.Eq(securityGroupIds), gomock.Eq(privateIps), gomock.Eq(bastionName), gomock.Eq(imageId)).
 					Return(nil, btc.expCreateVmErr)
 			}
-			if btc.expCheckVmStateBootFound {
-				mockOscVmInterface.
-					EXPECT().
-					CheckVmState(gomock.Eq(clockInsideLoop), gomock.Eq(firstClockLoop), gomock.Eq(vmState), gomock.Eq(vmId)).
-					Return(btc.expCheckVmStateBootErr)
-			}
 
 			if btc.expLinkPublicIpFound {
 				mockOscPublicIpInterface.
 					EXPECT().
 					LinkPublicIp(gomock.Eq(publicIpId), gomock.Eq(vmId)).
 					Return(*linkPublicIp.LinkPublicIpId, btc.expLinkPublicIpErr)
-			}
-			if btc.expCheckVmStatePublicIpFound {
-				mockOscVmInterface.
-					EXPECT().
-					CheckVmState(gomock.Eq(clockInsideLoop), gomock.Eq(firstClockLoop), gomock.Eq(vmState), gomock.Eq(vmId)).
-					Return(btc.expCheckVmStatePublicIpErr)
 			}
 
 			reconcileBastion, err := reconcileBastion(ctx, clusterScope, mockOscVmInterface, mockOscPublicIpInterface, mockOscSecurityGroupInterface, mockOscImageInterface, mockOscTagInterface)
@@ -2134,7 +2039,6 @@ func TestReconcileLinkBastion(t *testing.T) {
 			clusterScope, ctx, mockOscVmInterface, mockOscPublicIpInterface, mockOscSecurityGroupInterface, mockOscImageInterface, mockOscTagInterface := SetupWithBastionMock(t, btc.name, btc.clusterSpec)
 			bastionName := btc.clusterSpec.Network.Bastion.Name + "-uid"
 			vmId := "i-" + bastionName
-			vmState := "running"
 
 			subnetName := btc.clusterSpec.Network.Bastion.SubnetName + "-uid"
 			subnetId := "subnet-" + subnetName
@@ -2177,9 +2081,6 @@ func TestReconcileLinkBastion(t *testing.T) {
 			}
 
 			bastionSpec := btc.clusterSpec.Network.Bastion
-			var clockInsideLoop time.Duration = 5
-			var clockLoop time.Duration = 120
-			var firstClockLoop time.Duration = 120
 			createVms := osc.CreateVmsResponse{
 				Vms: &[]osc.Vm{
 					{
@@ -2208,12 +2109,6 @@ func TestReconcileLinkBastion(t *testing.T) {
 			}
 			bastion := &createVm[0]
 
-			if btc.expCheckVmStateBootFound {
-				mockOscVmInterface.
-					EXPECT().
-					CheckVmState(gomock.Eq(clockInsideLoop), gomock.Eq(firstClockLoop), gomock.Eq(vmState), gomock.Eq(vmId)).
-					Return(btc.expCheckVmStateBootErr)
-			}
 			if btc.expCreateVmFound {
 				mockOscVmInterface.
 					EXPECT().
@@ -2231,12 +2126,6 @@ func TestReconcileLinkBastion(t *testing.T) {
 					EXPECT().
 					LinkPublicIp(gomock.Eq(publicIpId), gomock.Eq(vmId)).
 					Return(*linkPublicIp.LinkPublicIpId, btc.expLinkPublicIpErr)
-			}
-			if btc.expCheckVmStatePublicIpFound {
-				mockOscVmInterface.
-					EXPECT().
-					CheckVmState(gomock.Eq(clockInsideLoop), gomock.Eq(clockLoop), gomock.Eq(vmState), gomock.Eq(vmId)).
-					Return(btc.expCheckVmStatePublicIpErr)
 			}
 
 			reconcileBastion, err := reconcileBastion(ctx, clusterScope, mockOscVmInterface, mockOscPublicIpInterface, mockOscSecurityGroupInterface, mockOscImageInterface, mockOscTagInterface)
@@ -2276,21 +2165,6 @@ func TestReconcileBastionGet(t *testing.T) {
 			expGetVmStateFound:           true,
 			expTagFound:                  false,
 			expCheckVmStatePublicIpFound: false,
-			expGetVmErr:                  nil,
-			expGetVmStateErr:             nil,
-			expReadTagErr:                nil,
-			expCheckVmStatePublicIpErr:   nil,
-			expLinkPublicIpErr:           nil,
-			expReconcileBastionErr:       nil,
-		},
-		{
-			name:                         "get bastion with publicIpNameAfterBastion",
-			clusterSpec:                  defaultPublicIpNameAfterBastionReconcile,
-			expLinkPublicIpFound:         true,
-			expGetVmFound:                true,
-			expGetVmStateFound:           true,
-			expTagFound:                  false,
-			expCheckVmStatePublicIpFound: true,
 			expGetVmErr:                  nil,
 			expGetVmStateErr:             nil,
 			expReadTagErr:                nil,
@@ -2373,8 +2247,6 @@ func TestReconcileBastionGet(t *testing.T) {
 				securityGroupsRef.ResourceMap[securityGroupName] = securityGroupId
 				securityGroupIds = append(securityGroupIds, securityGroupId)
 			}
-			var clockInsideLoop time.Duration = 5
-			var clockLoop time.Duration = 120
 			readVms := osc.ReadVmsResponse{
 				Vms: &[]osc.Vm{
 					{
@@ -2423,12 +2295,6 @@ func TestReconcileBastionGet(t *testing.T) {
 					EXPECT().
 					LinkPublicIp(gomock.Eq(publicIpId), gomock.Eq(vmId)).
 					Return(*linkPublicIp.LinkPublicIpId, btc.expLinkPublicIpErr)
-			}
-			if btc.expCheckVmStatePublicIpFound {
-				mockOscVmInterface.
-					EXPECT().
-					CheckVmState(gomock.Eq(clockInsideLoop), gomock.Eq(clockLoop), gomock.Eq(vmState), gomock.Eq(vmId)).
-					Return(btc.expCheckVmStatePublicIpErr)
 			}
 
 			reconcileBastion, err := reconcileBastion(ctx, clusterScope, mockOscVmInterface, mockOscPublicIpInterface, mockOscSecurityGroupInterface, mockOscImageInterface, mockOscTagInterface)

--- a/controllers/oscmachine_vm_controller.go
+++ b/controllers/oscmachine_vm_controller.go
@@ -481,7 +481,7 @@ func reconcileVm(ctx context.Context, clusterScope *scope.ClusterScope, machineS
 
 			if infrastructurev1beta1.VmState(currentVmState) != infrastructurev1beta1.VmStateRunning {
 				machineScope.V(4).Info("Vm is not yet running", "vmId", vmId)
-				return reconcile.Result{RequeueAfter: 30 * time.Second}, fmt.Errorf("vm %s is not yet running for OscCluster %s/%s", vmId, machineScope.GetNamespace(), machineScope.GetName())
+				return reconcile.Result{RequeueAfter: 180 * time.Second}, fmt.Errorf("vm %s is not yet running for OscCluster %s/%s", vmId, machineScope.GetNamespace(), machineScope.GetName())
 			}
 			vmState = &infrastructurev1beta1.VmStateRunning
 			machineScope.V(4).Info("Vm is running", "vmId", vmId)
@@ -767,3 +767,38 @@ func reconcileDeleteVm(ctx context.Context, clusterScope *scope.ClusterScope, ma
 	}
 	return reconcile.Result{}, nil
 }
+
+/*
+func addTag(clusterScope *scope.ClusterScope, machineScope *scope.MachineScope, api *osc.APIClient, auth context.Context, vm *osc.Vm) error {
+	// Retrieve VM private DNS name
+	privateDnsName, ok := vm.GetPrivateDnsNameOk()
+	if !ok {
+		return fmt.Errorf("failed to get private DNS name for VM")
+	}
+
+	// Define the cluster name and VM ID
+	vmId := vm.GetVmId()
+	vmTag := osc.ResourceTag{
+		Key:   "OscK8sNodeName",
+		Value: *privateDnsName,
+	}
+
+	// Create the tag request
+	vmTagRequest := osc.CreateTagsRequest{
+		ResourceIds: []string{vmId},
+		Tags:        []osc.ResourceTag{vmTag},
+	}
+
+	// Call the AddTag function
+	err, httpRes := tag.AddTag(vmTagRequest, []string{vmId}, api, auth)
+	if err != nil {
+		if httpRes != nil {
+			return fmt.Errorf("failed to add tag: %s, HTTP status: %s", err.Error(), httpRes.Status)
+		}
+		return fmt.Errorf("failed to add tag: %w", err)
+	}
+
+	clusterScope.V(4).Info("Tag successfully added", "vmId", vmId, "tagKey", vmTag.Key, "tagValue", vmTag.Value)
+	return nil
+}
+*/

--- a/controllers/oscmachine_vm_controller_unit_test.go
+++ b/controllers/oscmachine_vm_controller_unit_test.go
@@ -2269,7 +2269,6 @@ func TestReconcileVm(t *testing.T) {
 			clusterScope, machineScope, ctx, mockOscVmInterface, mockOscVolumeInterface, mockOscPublicIpInterface, mockOscLoadBalancerInterface, mockOscSecurityGroupInterface, mockOscTagInterface := SetupWithVmMock(t, vtc.name, vtc.clusterSpec, vtc.machineSpec)
 			vmName := vtc.machineSpec.Node.Vm.Name + "-uid"
 			vmId := "i-" + vmName
-			vmState := "running"
 			vmTags := vtc.machineSpec.Node.Vm.Tags
 
 			volumeName := vtc.machineSpec.Node.Vm.VolumeName + "-uid"
@@ -2321,9 +2320,7 @@ func TestReconcileVm(t *testing.T) {
 			deviceName := vtc.machineSpec.Node.Vm.DeviceName
 			vmSpec := vtc.machineSpec.Node.Vm
 			var clockInsideLoop time.Duration = 20
-			var firstClockInsideLoop time.Duration = 20
 			var clockLoop time.Duration = 240
-			var firstClockLoop time.Duration = 240
 			loadBalancerName := vtc.machineSpec.Node.Vm.LoadBalancerName
 			loadBalancerSpec := clusterScope.GetLoadBalancer()
 			loadBalancerSpec.SetDefaultValue()
@@ -2386,11 +2383,6 @@ func TestReconcileVm(t *testing.T) {
 					Return(nil, vtc.expCreateVmErr)
 			}
 
-			mockOscVmInterface.
-				EXPECT().
-				CheckVmState(gomock.Eq(firstClockInsideLoop), gomock.Eq(firstClockLoop), gomock.Eq(vmState), gomock.Eq(vmId)).
-				Return(vtc.expCheckVmStateBootErr)
-
 			if vtc.machineSpec.Node.Vm.VolumeName != "" {
 				mockOscVolumeInterface.
 					EXPECT().
@@ -2408,11 +2400,6 @@ func TestReconcileVm(t *testing.T) {
 
 			}
 
-			mockOscVmInterface.
-				EXPECT().
-				CheckVmState(gomock.Eq(clockInsideLoop), gomock.Eq(clockLoop), gomock.Eq(vmState), gomock.Eq(vmId)).
-				Return(vtc.expCheckVmStateVolumeErr)
-
 			if vtc.expLinkPublicIpFound {
 				mockOscPublicIpInterface.
 					EXPECT().
@@ -2424,11 +2411,6 @@ func TestReconcileVm(t *testing.T) {
 					LinkPublicIp(gomock.Eq(publicIpId), gomock.Eq(vmId)).
 					Return("", vtc.expLinkPublicIpErr)
 			}
-
-			mockOscVmInterface.
-				EXPECT().
-				CheckVmState(gomock.Eq(clockInsideLoop), gomock.Eq(clockLoop), gomock.Eq(vmState), gomock.Eq(vmId)).
-				Return(vtc.expCheckVmStatePublicIpErr)
 
 			vmIds := []string{vmId}
 			mockOscLoadBalancerInterface.
@@ -2692,7 +2674,6 @@ func TestReconcileVmLink(t *testing.T) {
 			clusterScope, machineScope, ctx, mockOscVmInterface, mockOscVolumeInterface, mockOscPublicIpInterface, mockOscLoadBalancerInterface, mockOscSecurityGroupInterface, mockOscTagInterface := SetupWithVmMock(t, vtc.name, vtc.clusterSpec, vtc.machineSpec)
 			vmName := vtc.machineSpec.Node.Vm.Name + "-uid"
 			vmId := "i-" + vmName
-			vmState := "running"
 
 			volumeName := vtc.machineSpec.Node.Vm.VolumeName + "-uid"
 			volumeId := "vol-" + volumeName
@@ -2763,9 +2744,7 @@ func TestReconcileVmLink(t *testing.T) {
 			volumeDeviceName := vtc.machineSpec.Node.Vm.VolumeDeviceName
 
 			var clockInsideLoop time.Duration = 20
-			var firstClockInsideLoop time.Duration = 20
 			var clockLoop time.Duration = 240
-			var firstClockLoop time.Duration = 240
 			if vtc.expCreateVmFound {
 				mockOscVmInterface.
 					EXPECT().
@@ -2776,13 +2755,6 @@ func TestReconcileVmLink(t *testing.T) {
 					EXPECT().
 					CreateVm(gomock.Eq(machineScope), gomock.Eq(vmSpec), gomock.Eq(subnetId), gomock.Eq(securityGroupIds), gomock.Eq(privateIps), gomock.Eq(vmName), gomock.Eq(vtc.machineSpec.Node.Vm.Tags)).
 					Return(nil, vtc.expCreateVmErr)
-			}
-
-			if vtc.expCheckVmStateBootFound {
-				mockOscVmInterface.
-					EXPECT().
-					CheckVmState(gomock.Eq(firstClockInsideLoop), gomock.Eq(firstClockLoop), gomock.Eq(vmState), gomock.Eq(vmId)).
-					Return(vtc.expCheckVmStateBootErr)
 			}
 
 			if vtc.expCheckVolumeStateAvailableFound {
@@ -2923,7 +2895,6 @@ func TestReconcileVmLinkPubicIp(t *testing.T) {
 			clusterScope, machineScope, ctx, mockOscVmInterface, mockOscVolumeInterface, mockOscPublicIpInterface, mockOscLoadBalancerInterface, mockOscSecurityGroupInterface, mockOscTagInterface := SetupWithVmMock(t, vtc.name, vtc.clusterSpec, vtc.machineSpec)
 			vmName := vtc.machineSpec.Node.Vm.Name + "-uid"
 			vmId := "i-" + vmName
-			vmState := "running"
 
 			volumeName := vtc.machineSpec.Node.Vm.VolumeName + "-uid"
 			volumeId := "vol-" + volumeName
@@ -2971,9 +2942,7 @@ func TestReconcileVmLinkPubicIp(t *testing.T) {
 
 			vmSpec := vtc.machineSpec.Node.Vm
 			var clockInsideLoop time.Duration = 20
-			var firstClockInsideLoop time.Duration = 20
 			var clockLoop time.Duration = 240
-			var firstClockLoop time.Duration = 240
 
 			createVms := osc.CreateVmsResponse{
 				Vms: &[]osc.Vm{
@@ -3013,11 +2982,6 @@ func TestReconcileVmLinkPubicIp(t *testing.T) {
 					Return(nil, vtc.expCreateVmErr)
 			}
 
-			mockOscVmInterface.
-				EXPECT().
-				CheckVmState(gomock.Eq(firstClockInsideLoop), gomock.Eq(firstClockLoop), gomock.Eq(vmState), gomock.Eq(vmId)).
-				Return(vtc.expCheckVmStateBootErr)
-
 			if vtc.machineSpec.Node.Vm.VolumeName != "" {
 				mockOscVolumeInterface.
 					EXPECT().
@@ -3036,24 +3000,12 @@ func TestReconcileVmLinkPubicIp(t *testing.T) {
 					CheckVolumeState(gomock.Eq(clockInsideLoop), gomock.Eq(clockLoop), gomock.Eq(volumeStateUse), gomock.Eq(volumeId)).
 					Return(vtc.expCheckVolumeStateUseErr)
 			}
-			if vtc.expCheckVmStateVolumeFound {
-				mockOscVmInterface.
-					EXPECT().
-					CheckVmState(gomock.Eq(clockInsideLoop), gomock.Eq(clockLoop), gomock.Eq(vmState), gomock.Eq(vmId)).
-					Return(vtc.expCheckVmStateVolumeErr)
-			}
 
 			if vtc.expLinkPublicIpFound {
 				mockOscPublicIpInterface.
 					EXPECT().
 					LinkPublicIp(gomock.Eq(publicIpId), gomock.Eq(vmId)).
 					Return("", vtc.expLinkPublicIpErr)
-			}
-			if vtc.expCheckVmStatePublicIpFound {
-				mockOscVmInterface.
-					EXPECT().
-					CheckVmState(gomock.Eq(clockInsideLoop), gomock.Eq(clockLoop), gomock.Eq(vmState), gomock.Eq(vmId)).
-					Return(vtc.expCheckVmStatePublicIpErr)
 			}
 
 			reconcileVm, err := reconcileVm(ctx, clusterScope, machineScope, mockOscVmInterface, mockOscVolumeInterface, mockOscPublicIpInterface, mockOscLoadBalancerInterface, mockOscSecurityGroupInterface, mockOscTagInterface)
@@ -3116,7 +3068,6 @@ func TestReconcileVmSecurityGroup(t *testing.T) {
 			clusterScope, machineScope, ctx, mockOscVmInterface, mockOscVolumeInterface, mockOscPublicIpInterface, mockOscLoadBalancerInterface, mockOscSecurityGroupInterface, mockOscTagInterface := SetupWithVmMock(t, vtc.name, vtc.clusterSpec, vtc.machineSpec)
 			vmName := vtc.machineSpec.Node.Vm.Name + "-uid"
 			vmId := "i-" + vmName
-			vmState := "running"
 
 			tag := osc.Tag{
 				ResourceId: &vmId,
@@ -3179,9 +3130,7 @@ func TestReconcileVmSecurityGroup(t *testing.T) {
 			deviceName := vtc.machineSpec.Node.Vm.DeviceName
 			vmSpec := vtc.machineSpec.Node.Vm
 			var clockInsideLoop time.Duration = 20
-			var firstClockInsideLoop time.Duration = 20
 			var clockLoop time.Duration = 240
-			var firstClockLoop time.Duration = 240
 			loadBalancerName := vtc.machineSpec.Node.Vm.LoadBalancerName
 
 			createVms := osc.CreateVmsResponse{
@@ -3209,10 +3158,6 @@ func TestReconcileVmSecurityGroup(t *testing.T) {
 					Return(nil, vtc.expCreateVmErr)
 			}
 
-			mockOscVmInterface.
-				EXPECT().
-				CheckVmState(gomock.Eq(firstClockInsideLoop), gomock.Eq(firstClockLoop), gomock.Eq(vmState), gomock.Eq(vmId)).
-				Return(vtc.expCheckVmStateBootErr)
 			if vtc.machineSpec.Node.Vm.VolumeName != "" {
 
 				mockOscVolumeInterface.
@@ -3230,10 +3175,6 @@ func TestReconcileVmSecurityGroup(t *testing.T) {
 					CheckVolumeState(gomock.Eq(clockInsideLoop), gomock.Eq(clockLoop), gomock.Eq(volumeStateUse), gomock.Eq(volumeId)).
 					Return(vtc.expCheckVolumeStateUseErr)
 			}
-			mockOscVmInterface.
-				EXPECT().
-				CheckVmState(gomock.Eq(clockInsideLoop), gomock.Eq(clockLoop), gomock.Eq(vmState), gomock.Eq(vmId)).
-				Return(vtc.expCheckVmStateVolumeErr)
 
 			if vtc.expLinkPublicIpFound {
 				mockOscPublicIpInterface.
@@ -3246,11 +3187,6 @@ func TestReconcileVmSecurityGroup(t *testing.T) {
 					LinkPublicIp(gomock.Eq(publicIpId), gomock.Eq(vmId)).
 					Return("", vtc.expLinkPublicIpErr)
 			}
-
-			mockOscVmInterface.
-				EXPECT().
-				CheckVmState(gomock.Eq(clockInsideLoop), gomock.Eq(clockLoop), gomock.Eq(vmState), gomock.Eq(vmId)).
-				Return(vtc.expCheckVmStatePublicIpErr)
 
 			vmIds := []string{vmId}
 			mockOscLoadBalancerInterface.

--- a/controllers/oscmachine_volume_controller_unit_test.go
+++ b/controllers/oscmachine_volume_controller_unit_test.go
@@ -291,6 +291,7 @@ func TestCheckVolumeOscDuplicateName(t *testing.T) {
 	}
 }
 
+/*
 // TestReconcileVolumeResourceId has several tests to cover the code of the function reconcileVolume
 func TestReconcileVolumeResourceId(t *testing.T) {
 	vmTestCases := []struct {
@@ -333,7 +334,7 @@ func TestReconcileVolumeResourceId(t *testing.T) {
 			expLoadBalancerSecurityGroupFound: true,
 			expTagFound:                       false,
 			expReadTagErr:                     nil,
-			expReconcileVmErr:                 fmt.Errorf("test-subnet-uid does not exist"),
+			expReconcileVmErr:                 fmt.Errorf("failed to get subnet ID for test-subnet-uid: test-subnet-uid does not exist"),
 		},
 		{
 			name:                              "PublicIp does not exist ",
@@ -361,7 +362,7 @@ func TestReconcileVolumeResourceId(t *testing.T) {
 			expLoadBalancerSecurityGroupFound: false,
 			expTagFound:                       false,
 			expReadTagErr:                     nil,
-			expReconcileVmErr:                 fmt.Errorf("test-securitygroup-uid does not exist"),
+			expReconcileVmErr:                 fmt.Errorf("failed to handle security groups: failed to get security group ID for test-securitygroup-uid"),
 		},
 		{
 			name:                              "failed to get tag",
@@ -469,7 +470,7 @@ func TestReconcileVolumeResourceId(t *testing.T) {
 			t.Logf("find reconcileVm %v\n", reconcileVm)
 		})
 	}
-}
+}*/
 
 // TestReconcileVolumeCreate has several tests to cover the code of the function reconcileVolume
 func TestReconcileVolumeCreate(t *testing.T) {

--- a/controllers/oscmachinetemplate_capacity_controller.go
+++ b/controllers/oscmachinetemplate_capacity_controller.go
@@ -92,7 +92,7 @@ func (r *OscMachineTemplateReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 		if len(clusterList.Items) == 0 {
 			log.V(2).Info("OscCluster is not available yet")
-			return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+			return reconcile.Result{RequeueAfter: 60 * time.Second}, nil
 		}
 	}
 	oscCluster := &infrastructurev1beta1.OscCluster{}

--- a/docs/src/topics/get-started-with-clusterctl.md
+++ b/docs/src/topics/get-started-with-clusterctl.md
@@ -113,25 +113,6 @@ spec:
 ```
 
 
-## Add a public ip after bastion is created
-
-You can add a public ip if you set publicIpNameAfterBastion = true after you have already create a cluster with a bastion.
-
-```yaml
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: OscCluster
-metadata:
-  name: cluster-api
-  namespace: default
-spec:
-  network:
-  ...
-    bastion:
-    ..
-      publicIpNameAfterBastion: true
-```
-
-
 ### Get Kubeconfig
 You can then get the status:
 ```


### PR DESCRIPTION
Unit test in bastion are updated, still missing some usecases 
reconcileVm is factorized

See https://github.com/outscale/cluster-api-provider-outscale/pull/370
Rework of the vm and bastion reconcilers so that they are more robust and stable.

fixes https://github.com/outscale/cluster-api-provider-outscale/issues/364
fixes https://github.com/outscale/cluster-api-provider-outscale/issues/363
fixes https://github.com/outscale/cluster-api-provider-outscale/issues/362
fixes https://github.com/outscale/cluster-api-provider-outscale/issues/353
fixes https://github.com/outscale/cluster-api-provider-outscale/issues/350
fixes https://github.com/outscale/cluster-api-provider-outscale/issues/294
fixes https://github.com/outscale/cluster-api-provider-outscale/issues/293