### PR TITLE
Replace Deprecated gcr.io/kubebuilder/kube-rbac-proxy

### DIFF
--- a/capm.yaml
+++ b/capm.yaml
@@ -1573,7 +1573,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=6
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: ghcr.io/brancz/kube-rbac-proxy:v0.13.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/cluster-api-provider-outscale-manifest.yaml
+++ b/cluster-api-provider-outscale-manifest.yaml
@@ -1548,7 +1548,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=6
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: ghcr.io/brancz/kube-rbac-proxy:v0.13.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: ghcr.io/brancz/kube-rbac-proxy:v0.13.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/helm/clusterapioutscale/README.md
+++ b/helm/clusterapioutscale/README.md
@@ -21,8 +21,8 @@ Deploy Outscale Cluster API. Please look at deploy.md
 | deployment.imagePullSecrets | list | `[]` | Specify image pull secrets |
 | deployment.imageTag | string | `"v0.1.0"` | Outscale provider image tag |
 | deployment.labels | object | `nil` | Labels to set on pods |
-| deployment.proxyImage | string | `"gcr.io/kubebuilder/kube-rbac-proxy"` | Proxy image |
-| deployment.proxyImageTag | string | `"v0.8.0"` | Proxy image tag |
+| deployment.proxyImage | string | `"ghcr.io/brancz/kube-rbac-proxy"` | Proxy image |
+| deployment.proxyImageTag | string | `"v0.13.0"` | Proxy image tag |
 | deployment.proxyResources | object | `{"cpu":{"limits":"200m","requests":"100m"},"memory":{"limits":"30Mi","requests":"20Mi"}}` | Proxy container resource limit/requests (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | deployment.proxyResources.cpu.limits | string | `"200m"` | Container proxy cpu limits |
 | deployment.proxyResources.cpu.requests | string | `"100m"` | Container proxy cpu requests |

--- a/helm/clusterapioutscale/values.yaml
+++ b/helm/clusterapioutscale/values.yaml
@@ -44,9 +44,9 @@ deployment:
       # -- Container cpu limts
       limits: 200m
   # -- Proxy image
-  proxyImage: gcr.io/kubebuilder/kube-rbac-proxy
+  proxyImage: ghcr.io/brancz/kube-rbac-proxy
   # -- Proxy image tag
-  proxyImageTag: "v0.8.0"
+  proxyImageTag: "v0.13.0"
   # -- Proxy container resource limit/requests (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
   proxyResources:
     memory:

--- a/main.go
+++ b/main.go
@@ -81,6 +81,8 @@ func main() {
 		Scheme: scheme,
 		Metrics: server.Options{
 			BindAddress: metricsAddr,
+			// Enable authentication and authorization for metrics
+			//WithAuthenticationAndAuthorization: true,
 		},
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,

--- a/test/e2e/data/infrastructure-outscale/infrastructure-components.yaml
+++ b/test/e2e/data/infrastructure-outscale/infrastructure-components.yaml
@@ -727,7 +727,7 @@ spec:
             - --upstream=http://127.0.0.1:8080/
             - --logtostderr=true
             - --v=0
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+          image: ghcr.io/brancz/kube-rbac-proxy:v0.13.0
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443


### PR DESCRIPTION
See https://github.com/outscale/cluster-api-provider-outscale/issues/397
