### PR TITLE
Fix helm chart with default values

### DIFF
--- a/helm/clusterapioutscale/templates/deployment.yaml
+++ b/helm/clusterapioutscale/templates/deployment.yaml
@@ -123,7 +123,6 @@ spec:
         {{- range $key, $val := .containers.securityContext }}
           {{ $key }}: {{ $val }}
         {{- end }}
-          allowPrivilegeEscalation: false
       {{- end }}
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs


### PR DESCRIPTION
Helm chart default values add the securityContext 'allowPrivilegeEscalation: false' which is also the case hardcoded in the deployment template. This result to the following error when installing the chart with default values:

mapping key "allowPrivilegeEscalation" already defined

Fixed by removing the hardcoded value in templates to rely on values.yaml only

<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->

**What type of PR is this?**

/kind bug               Fixes a newly discovered bug.

**What this PR does / why we need it**:

Default values for helm chart doesn't work

**Which issue(s) this PR fixes**:
Fixes #406

**TODOs**:

- [X] squashed commits
- [X] includes documentation
- [X] adds unit tests
