### PR TITLE
🔊 logs: refactored logs, based on context and not scopes

### DIFF
--- a/cloud/scope/clients.go
+++ b/cloud/scope/clients.go
@@ -45,7 +45,7 @@ func newOscClient() (*OscClient, error) {
 		version = "DEV"
 	}
 	config := osc.NewConfiguration()
-	config.Debug = true
+	// config.Debug = true
 	config.UserAgent = "cluster-api-provider-outscale/" + version
 	auth := context.WithValue(context.Background(), osc.ContextAWSv4, osc.AWSv4{
 		AccessKey: os.Getenv("OSC_ACCESS_KEY"),

--- a/cloud/services/compute/image.go
+++ b/cloud/services/compute/image.go
@@ -17,9 +17,11 @@ limitations under the License.
 package compute
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
+	"github.com/outscale/cluster-api-provider-outscale/cloud/utils"
 	"github.com/outscale/cluster-api-provider-outscale/util/reconciler"
 	osc "github.com/outscale/osc-sdk-go/v2"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -27,13 +29,13 @@ import (
 
 //go:generate ../../../bin/mockgen -destination mock_compute/image_mock.go -package mock_compute -source ./image.go
 type OscImageInterface interface {
-	GetImage(imageId string) (*osc.Image, error)
-	GetImageId(imageName string) (string, error)
-	GetImageName(imageId string) (string, error)
+	GetImage(ctx context.Context, imageId string) (*osc.Image, error)
+	GetImageId(ctx context.Context, imageName string) (string, error)
+	GetImageName(ctx context.Context, imageId string) (string, error)
 }
 
 // GetImage retrieve image from imageId
-func (s *Service) GetImage(imageId string) (*osc.Image, error) {
+func (s *Service) GetImage(ctx context.Context, imageId string) (*osc.Image, error) {
 	readImageRequest := osc.ReadImagesRequest{
 		Filters: &osc.FiltersImage{ImageIds: &[]string{imageId}},
 	}
@@ -45,6 +47,7 @@ func (s *Service) GetImage(imageId string) (*osc.Image, error) {
 		var httpRes *http.Response
 		var err error
 		readImagesResponse, httpRes, err = oscApiClient.ImageApi.ReadImages(oscAuthClient).ReadImagesRequest(readImageRequest).Execute()
+		utils.LogAPICall(ctx, "ReadImages", readImageRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
 				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
@@ -74,7 +77,7 @@ func (s *Service) GetImage(imageId string) (*osc.Image, error) {
 }
 
 // GetImageId retrieve imageId from imageName
-func (s *Service) GetImageId(imageName string) (string, error) {
+func (s *Service) GetImageId(ctx context.Context, imageName string) (string, error) {
 	readImageRequest := osc.ReadImagesRequest{
 		Filters: &osc.FiltersImage{ImageNames: &[]string{imageName}},
 	}
@@ -85,6 +88,7 @@ func (s *Service) GetImageId(imageName string) (string, error) {
 		var httpRes *http.Response
 		var err error
 		readImagesResponse, httpRes, err = oscApiClient.ImageApi.ReadImages(oscAuthClient).ReadImagesRequest(readImageRequest).Execute()
+		utils.LogAPICall(ctx, "ReadImages", readImageRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
 				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
@@ -114,7 +118,7 @@ func (s *Service) GetImageId(imageName string) (string, error) {
 }
 
 // GetImageName retrieve imageId from imageName
-func (s *Service) GetImageName(imageId string) (string, error) {
+func (s *Service) GetImageName(ctx context.Context, imageId string) (string, error) {
 	readImageRequest := osc.ReadImagesRequest{
 		Filters: &osc.FiltersImage{ImageNames: &[]string{imageId}},
 	}
@@ -125,6 +129,7 @@ func (s *Service) GetImageName(imageId string) (string, error) {
 		var httpRes *http.Response
 		var err error
 		readImagesResponse, httpRes, err = oscApiClient.ImageApi.ReadImages(oscAuthClient).ReadImagesRequest(readImageRequest).Execute()
+		utils.LogAPICall(ctx, "ReadImages", readImageRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
 				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)

--- a/cloud/services/compute/mock_compute/image_mock.go
+++ b/cloud/services/compute/mock_compute/image_mock.go
@@ -5,6 +5,7 @@
 package mock_compute
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -35,46 +36,46 @@ func (m *MockOscImageInterface) EXPECT() *MockOscImageInterfaceMockRecorder {
 }
 
 // GetImage mocks base method.
-func (m *MockOscImageInterface) GetImage(imageId string) (*osc.Image, error) {
+func (m *MockOscImageInterface) GetImage(ctx context.Context, imageId string) (*osc.Image, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetImage", imageId)
+	ret := m.ctrl.Call(m, "GetImage", ctx, imageId)
 	ret0, _ := ret[0].(*osc.Image)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetImage indicates an expected call of GetImage.
-func (mr *MockOscImageInterfaceMockRecorder) GetImage(imageId interface{}) *gomock.Call {
+func (mr *MockOscImageInterfaceMockRecorder) GetImage(ctx, imageId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImage", reflect.TypeOf((*MockOscImageInterface)(nil).GetImage), imageId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImage", reflect.TypeOf((*MockOscImageInterface)(nil).GetImage), ctx, imageId)
 }
 
 // GetImageId mocks base method.
-func (m *MockOscImageInterface) GetImageId(imageName string) (string, error) {
+func (m *MockOscImageInterface) GetImageId(ctx context.Context, imageName string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetImageId", imageName)
+	ret := m.ctrl.Call(m, "GetImageId", ctx, imageName)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetImageId indicates an expected call of GetImageId.
-func (mr *MockOscImageInterfaceMockRecorder) GetImageId(imageName interface{}) *gomock.Call {
+func (mr *MockOscImageInterfaceMockRecorder) GetImageId(ctx, imageName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageId", reflect.TypeOf((*MockOscImageInterface)(nil).GetImageId), imageName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageId", reflect.TypeOf((*MockOscImageInterface)(nil).GetImageId), ctx, imageName)
 }
 
 // GetImageName mocks base method.
-func (m *MockOscImageInterface) GetImageName(imageId string) (string, error) {
+func (m *MockOscImageInterface) GetImageName(ctx context.Context, imageId string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetImageName", imageId)
+	ret := m.ctrl.Call(m, "GetImageName", ctx, imageId)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetImageName indicates an expected call of GetImageName.
-func (mr *MockOscImageInterfaceMockRecorder) GetImageName(imageId interface{}) *gomock.Call {
+func (mr *MockOscImageInterfaceMockRecorder) GetImageName(ctx, imageId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageName", reflect.TypeOf((*MockOscImageInterface)(nil).GetImageName), imageId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageName", reflect.TypeOf((*MockOscImageInterface)(nil).GetImageName), ctx, imageId)
 }

--- a/cloud/services/compute/mock_compute/vm_mock.go
+++ b/cloud/services/compute/mock_compute/vm_mock.go
@@ -5,6 +5,7 @@
 package mock_compute
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -38,119 +39,119 @@ func (m *MockOscVmInterface) EXPECT() *MockOscVmInterfaceMockRecorder {
 }
 
 // AddCcmTag mocks base method.
-func (m *MockOscVmInterface) AddCcmTag(clusterName, hostname, vmId string) error {
+func (m *MockOscVmInterface) AddCcmTag(ctx context.Context, clusterName, hostname, vmId string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddCcmTag", clusterName, hostname, vmId)
+	ret := m.ctrl.Call(m, "AddCcmTag", ctx, clusterName, hostname, vmId)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AddCcmTag indicates an expected call of AddCcmTag.
-func (mr *MockOscVmInterfaceMockRecorder) AddCcmTag(clusterName, hostname, vmId interface{}) *gomock.Call {
+func (mr *MockOscVmInterfaceMockRecorder) AddCcmTag(ctx, clusterName, hostname, vmId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddCcmTag", reflect.TypeOf((*MockOscVmInterface)(nil).AddCcmTag), clusterName, hostname, vmId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddCcmTag", reflect.TypeOf((*MockOscVmInterface)(nil).AddCcmTag), ctx, clusterName, hostname, vmId)
 }
 
 // CreateVm mocks base method.
-func (m *MockOscVmInterface) CreateVm(machineScope *scope.MachineScope, spec *v1beta1.OscVm, subnetId string, securityGroupIds, privateIps []string, vmName string, tags map[string]string) (*osc.Vm, error) {
+func (m *MockOscVmInterface) CreateVm(ctx context.Context, machineScope *scope.MachineScope, spec *v1beta1.OscVm, subnetId string, securityGroupIds, privateIps []string, vmName string, tags map[string]string) (*osc.Vm, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateVm", machineScope, spec, subnetId, securityGroupIds, privateIps, vmName, tags)
+	ret := m.ctrl.Call(m, "CreateVm", ctx, machineScope, spec, subnetId, securityGroupIds, privateIps, vmName, tags)
 	ret0, _ := ret[0].(*osc.Vm)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateVm indicates an expected call of CreateVm.
-func (mr *MockOscVmInterfaceMockRecorder) CreateVm(machineScope, spec, subnetId, securityGroupIds, privateIps, vmName, tags interface{}) *gomock.Call {
+func (mr *MockOscVmInterfaceMockRecorder) CreateVm(ctx, machineScope, spec, subnetId, securityGroupIds, privateIps, vmName, tags interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVm", reflect.TypeOf((*MockOscVmInterface)(nil).CreateVm), machineScope, spec, subnetId, securityGroupIds, privateIps, vmName, tags)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVm", reflect.TypeOf((*MockOscVmInterface)(nil).CreateVm), ctx, machineScope, spec, subnetId, securityGroupIds, privateIps, vmName, tags)
 }
 
 // CreateVmUserData mocks base method.
-func (m *MockOscVmInterface) CreateVmUserData(userData string, spec *v1beta1.OscBastion, subnetId string, securityGroupIds, privateIps []string, vmName, imageId string) (*osc.Vm, error) {
+func (m *MockOscVmInterface) CreateVmUserData(ctx context.Context, userData string, spec *v1beta1.OscBastion, subnetId string, securityGroupIds, privateIps []string, vmName, imageId string) (*osc.Vm, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateVmUserData", userData, spec, subnetId, securityGroupIds, privateIps, vmName, imageId)
+	ret := m.ctrl.Call(m, "CreateVmUserData", ctx, userData, spec, subnetId, securityGroupIds, privateIps, vmName, imageId)
 	ret0, _ := ret[0].(*osc.Vm)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateVmUserData indicates an expected call of CreateVmUserData.
-func (mr *MockOscVmInterfaceMockRecorder) CreateVmUserData(userData, spec, subnetId, securityGroupIds, privateIps, vmName, imageId interface{}) *gomock.Call {
+func (mr *MockOscVmInterfaceMockRecorder) CreateVmUserData(ctx, userData, spec, subnetId, securityGroupIds, privateIps, vmName, imageId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVmUserData", reflect.TypeOf((*MockOscVmInterface)(nil).CreateVmUserData), userData, spec, subnetId, securityGroupIds, privateIps, vmName, imageId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVmUserData", reflect.TypeOf((*MockOscVmInterface)(nil).CreateVmUserData), ctx, userData, spec, subnetId, securityGroupIds, privateIps, vmName, imageId)
 }
 
 // DeleteVm mocks base method.
-func (m *MockOscVmInterface) DeleteVm(vmId string) error {
+func (m *MockOscVmInterface) DeleteVm(ctx context.Context, vmId string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteVm", vmId)
+	ret := m.ctrl.Call(m, "DeleteVm", ctx, vmId)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteVm indicates an expected call of DeleteVm.
-func (mr *MockOscVmInterfaceMockRecorder) DeleteVm(vmId interface{}) *gomock.Call {
+func (mr *MockOscVmInterfaceMockRecorder) DeleteVm(ctx, vmId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVm", reflect.TypeOf((*MockOscVmInterface)(nil).DeleteVm), vmId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVm", reflect.TypeOf((*MockOscVmInterface)(nil).DeleteVm), ctx, vmId)
 }
 
 // GetCapacity mocks base method.
-func (m *MockOscVmInterface) GetCapacity(tagKey, tagValue, vmType string) (v1.ResourceList, error) {
+func (m *MockOscVmInterface) GetCapacity(ctx context.Context, tagKey, tagValue, vmType string) (v1.ResourceList, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCapacity", tagKey, tagValue, vmType)
+	ret := m.ctrl.Call(m, "GetCapacity", ctx, tagKey, tagValue, vmType)
 	ret0, _ := ret[0].(v1.ResourceList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetCapacity indicates an expected call of GetCapacity.
-func (mr *MockOscVmInterfaceMockRecorder) GetCapacity(tagKey, tagValue, vmType interface{}) *gomock.Call {
+func (mr *MockOscVmInterfaceMockRecorder) GetCapacity(ctx, tagKey, tagValue, vmType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCapacity", reflect.TypeOf((*MockOscVmInterface)(nil).GetCapacity), tagKey, tagValue, vmType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCapacity", reflect.TypeOf((*MockOscVmInterface)(nil).GetCapacity), ctx, tagKey, tagValue, vmType)
 }
 
 // GetVm mocks base method.
-func (m *MockOscVmInterface) GetVm(vmId string) (*osc.Vm, error) {
+func (m *MockOscVmInterface) GetVm(ctx context.Context, vmId string) (*osc.Vm, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetVm", vmId)
+	ret := m.ctrl.Call(m, "GetVm", ctx, vmId)
 	ret0, _ := ret[0].(*osc.Vm)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetVm indicates an expected call of GetVm.
-func (mr *MockOscVmInterfaceMockRecorder) GetVm(vmId interface{}) *gomock.Call {
+func (mr *MockOscVmInterfaceMockRecorder) GetVm(ctx, vmId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVm", reflect.TypeOf((*MockOscVmInterface)(nil).GetVm), vmId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVm", reflect.TypeOf((*MockOscVmInterface)(nil).GetVm), ctx, vmId)
 }
 
 // GetVmListFromTag mocks base method.
-func (m *MockOscVmInterface) GetVmListFromTag(tagKey, tagName string) ([]osc.Vm, error) {
+func (m *MockOscVmInterface) GetVmListFromTag(ctx context.Context, tagKey, tagName string) ([]osc.Vm, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetVmListFromTag", tagKey, tagName)
+	ret := m.ctrl.Call(m, "GetVmListFromTag", ctx, tagKey, tagName)
 	ret0, _ := ret[0].([]osc.Vm)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetVmListFromTag indicates an expected call of GetVmListFromTag.
-func (mr *MockOscVmInterfaceMockRecorder) GetVmListFromTag(tagKey, tagName interface{}) *gomock.Call {
+func (mr *MockOscVmInterfaceMockRecorder) GetVmListFromTag(ctx, tagKey, tagName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVmListFromTag", reflect.TypeOf((*MockOscVmInterface)(nil).GetVmListFromTag), tagKey, tagName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVmListFromTag", reflect.TypeOf((*MockOscVmInterface)(nil).GetVmListFromTag), ctx, tagKey, tagName)
 }
 
 // GetVmState mocks base method.
-func (m *MockOscVmInterface) GetVmState(vmId string) (string, error) {
+func (m *MockOscVmInterface) GetVmState(ctx context.Context, vmId string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetVmState", vmId)
+	ret := m.ctrl.Call(m, "GetVmState", ctx, vmId)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetVmState indicates an expected call of GetVmState.
-func (mr *MockOscVmInterfaceMockRecorder) GetVmState(vmId interface{}) *gomock.Call {
+func (mr *MockOscVmInterfaceMockRecorder) GetVmState(ctx, vmId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVmState", reflect.TypeOf((*MockOscVmInterface)(nil).GetVmState), vmId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVmState", reflect.TypeOf((*MockOscVmInterface)(nil).GetVmState), ctx, vmId)
 }

--- a/cloud/services/net/mock_net/internetservice_mock.go
+++ b/cloud/services/net/mock_net/internetservice_mock.go
@@ -5,6 +5,7 @@
 package mock_net
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -35,73 +36,73 @@ func (m *MockOscInternetServiceInterface) EXPECT() *MockOscInternetServiceInterf
 }
 
 // CreateInternetService mocks base method.
-func (m *MockOscInternetServiceInterface) CreateInternetService(internetServiceName string) (*osc.InternetService, error) {
+func (m *MockOscInternetServiceInterface) CreateInternetService(ctx context.Context, internetServiceName string) (*osc.InternetService, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateInternetService", internetServiceName)
+	ret := m.ctrl.Call(m, "CreateInternetService", ctx, internetServiceName)
 	ret0, _ := ret[0].(*osc.InternetService)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateInternetService indicates an expected call of CreateInternetService.
-func (mr *MockOscInternetServiceInterfaceMockRecorder) CreateInternetService(internetServiceName interface{}) *gomock.Call {
+func (mr *MockOscInternetServiceInterfaceMockRecorder) CreateInternetService(ctx, internetServiceName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInternetService", reflect.TypeOf((*MockOscInternetServiceInterface)(nil).CreateInternetService), internetServiceName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInternetService", reflect.TypeOf((*MockOscInternetServiceInterface)(nil).CreateInternetService), ctx, internetServiceName)
 }
 
 // DeleteInternetService mocks base method.
-func (m *MockOscInternetServiceInterface) DeleteInternetService(internetServiceId string) error {
+func (m *MockOscInternetServiceInterface) DeleteInternetService(ctx context.Context, internetServiceId string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteInternetService", internetServiceId)
+	ret := m.ctrl.Call(m, "DeleteInternetService", ctx, internetServiceId)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteInternetService indicates an expected call of DeleteInternetService.
-func (mr *MockOscInternetServiceInterfaceMockRecorder) DeleteInternetService(internetServiceId interface{}) *gomock.Call {
+func (mr *MockOscInternetServiceInterfaceMockRecorder) DeleteInternetService(ctx, internetServiceId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteInternetService", reflect.TypeOf((*MockOscInternetServiceInterface)(nil).DeleteInternetService), internetServiceId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteInternetService", reflect.TypeOf((*MockOscInternetServiceInterface)(nil).DeleteInternetService), ctx, internetServiceId)
 }
 
 // GetInternetService mocks base method.
-func (m *MockOscInternetServiceInterface) GetInternetService(internetServiceId string) (*osc.InternetService, error) {
+func (m *MockOscInternetServiceInterface) GetInternetService(ctx context.Context, internetServiceId string) (*osc.InternetService, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetInternetService", internetServiceId)
+	ret := m.ctrl.Call(m, "GetInternetService", ctx, internetServiceId)
 	ret0, _ := ret[0].(*osc.InternetService)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetInternetService indicates an expected call of GetInternetService.
-func (mr *MockOscInternetServiceInterfaceMockRecorder) GetInternetService(internetServiceId interface{}) *gomock.Call {
+func (mr *MockOscInternetServiceInterfaceMockRecorder) GetInternetService(ctx, internetServiceId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInternetService", reflect.TypeOf((*MockOscInternetServiceInterface)(nil).GetInternetService), internetServiceId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInternetService", reflect.TypeOf((*MockOscInternetServiceInterface)(nil).GetInternetService), ctx, internetServiceId)
 }
 
 // LinkInternetService mocks base method.
-func (m *MockOscInternetServiceInterface) LinkInternetService(internetServiceId, netId string) error {
+func (m *MockOscInternetServiceInterface) LinkInternetService(ctx context.Context, internetServiceId, netId string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LinkInternetService", internetServiceId, netId)
+	ret := m.ctrl.Call(m, "LinkInternetService", ctx, internetServiceId, netId)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // LinkInternetService indicates an expected call of LinkInternetService.
-func (mr *MockOscInternetServiceInterfaceMockRecorder) LinkInternetService(internetServiceId, netId interface{}) *gomock.Call {
+func (mr *MockOscInternetServiceInterfaceMockRecorder) LinkInternetService(ctx, internetServiceId, netId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkInternetService", reflect.TypeOf((*MockOscInternetServiceInterface)(nil).LinkInternetService), internetServiceId, netId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkInternetService", reflect.TypeOf((*MockOscInternetServiceInterface)(nil).LinkInternetService), ctx, internetServiceId, netId)
 }
 
 // UnlinkInternetService mocks base method.
-func (m *MockOscInternetServiceInterface) UnlinkInternetService(internetServiceId, netId string) error {
+func (m *MockOscInternetServiceInterface) UnlinkInternetService(ctx context.Context, internetServiceId, netId string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnlinkInternetService", internetServiceId, netId)
+	ret := m.ctrl.Call(m, "UnlinkInternetService", ctx, internetServiceId, netId)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UnlinkInternetService indicates an expected call of UnlinkInternetService.
-func (mr *MockOscInternetServiceInterfaceMockRecorder) UnlinkInternetService(internetServiceId, netId interface{}) *gomock.Call {
+func (mr *MockOscInternetServiceInterfaceMockRecorder) UnlinkInternetService(ctx, internetServiceId, netId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnlinkInternetService", reflect.TypeOf((*MockOscInternetServiceInterface)(nil).UnlinkInternetService), internetServiceId, netId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnlinkInternetService", reflect.TypeOf((*MockOscInternetServiceInterface)(nil).UnlinkInternetService), ctx, internetServiceId, netId)
 }

--- a/cloud/services/net/mock_net/natservice_mock.go
+++ b/cloud/services/net/mock_net/natservice_mock.go
@@ -5,6 +5,7 @@
 package mock_net
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -35,45 +36,45 @@ func (m *MockOscNatServiceInterface) EXPECT() *MockOscNatServiceInterfaceMockRec
 }
 
 // CreateNatService mocks base method.
-func (m *MockOscNatServiceInterface) CreateNatService(publicIpId, subnetId, natServiceName, clusterName string) (*osc.NatService, error) {
+func (m *MockOscNatServiceInterface) CreateNatService(ctx context.Context, publicIpId, subnetId, natServiceName, clusterName string) (*osc.NatService, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateNatService", publicIpId, subnetId, natServiceName, clusterName)
+	ret := m.ctrl.Call(m, "CreateNatService", ctx, publicIpId, subnetId, natServiceName, clusterName)
 	ret0, _ := ret[0].(*osc.NatService)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateNatService indicates an expected call of CreateNatService.
-func (mr *MockOscNatServiceInterfaceMockRecorder) CreateNatService(publicIpId, subnetId, natServiceName, clusterName interface{}) *gomock.Call {
+func (mr *MockOscNatServiceInterfaceMockRecorder) CreateNatService(ctx, publicIpId, subnetId, natServiceName, clusterName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNatService", reflect.TypeOf((*MockOscNatServiceInterface)(nil).CreateNatService), publicIpId, subnetId, natServiceName, clusterName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNatService", reflect.TypeOf((*MockOscNatServiceInterface)(nil).CreateNatService), ctx, publicIpId, subnetId, natServiceName, clusterName)
 }
 
 // DeleteNatService mocks base method.
-func (m *MockOscNatServiceInterface) DeleteNatService(natServiceId string) error {
+func (m *MockOscNatServiceInterface) DeleteNatService(ctx context.Context, natServiceId string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteNatService", natServiceId)
+	ret := m.ctrl.Call(m, "DeleteNatService", ctx, natServiceId)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteNatService indicates an expected call of DeleteNatService.
-func (mr *MockOscNatServiceInterfaceMockRecorder) DeleteNatService(natServiceId interface{}) *gomock.Call {
+func (mr *MockOscNatServiceInterfaceMockRecorder) DeleteNatService(ctx, natServiceId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNatService", reflect.TypeOf((*MockOscNatServiceInterface)(nil).DeleteNatService), natServiceId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNatService", reflect.TypeOf((*MockOscNatServiceInterface)(nil).DeleteNatService), ctx, natServiceId)
 }
 
 // GetNatService mocks base method.
-func (m *MockOscNatServiceInterface) GetNatService(natServiceId string) (*osc.NatService, error) {
+func (m *MockOscNatServiceInterface) GetNatService(ctx context.Context, natServiceId string) (*osc.NatService, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNatService", natServiceId)
+	ret := m.ctrl.Call(m, "GetNatService", ctx, natServiceId)
 	ret0, _ := ret[0].(*osc.NatService)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetNatService indicates an expected call of GetNatService.
-func (mr *MockOscNatServiceInterfaceMockRecorder) GetNatService(natServiceId interface{}) *gomock.Call {
+func (mr *MockOscNatServiceInterfaceMockRecorder) GetNatService(ctx, natServiceId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNatService", reflect.TypeOf((*MockOscNatServiceInterface)(nil).GetNatService), natServiceId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNatService", reflect.TypeOf((*MockOscNatServiceInterface)(nil).GetNatService), ctx, natServiceId)
 }

--- a/cloud/services/net/mock_net/net_mock.go
+++ b/cloud/services/net/mock_net/net_mock.go
@@ -5,6 +5,7 @@
 package mock_net
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -36,45 +37,45 @@ func (m *MockOscNetInterface) EXPECT() *MockOscNetInterfaceMockRecorder {
 }
 
 // CreateNet mocks base method.
-func (m *MockOscNetInterface) CreateNet(spec *v1beta1.OscNet, clusterName, netName string) (*osc.Net, error) {
+func (m *MockOscNetInterface) CreateNet(ctx context.Context, spec *v1beta1.OscNet, clusterName, netName string) (*osc.Net, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateNet", spec, clusterName, netName)
+	ret := m.ctrl.Call(m, "CreateNet", ctx, spec, clusterName, netName)
 	ret0, _ := ret[0].(*osc.Net)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateNet indicates an expected call of CreateNet.
-func (mr *MockOscNetInterfaceMockRecorder) CreateNet(spec, clusterName, netName interface{}) *gomock.Call {
+func (mr *MockOscNetInterfaceMockRecorder) CreateNet(ctx, spec, clusterName, netName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNet", reflect.TypeOf((*MockOscNetInterface)(nil).CreateNet), spec, clusterName, netName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNet", reflect.TypeOf((*MockOscNetInterface)(nil).CreateNet), ctx, spec, clusterName, netName)
 }
 
 // DeleteNet mocks base method.
-func (m *MockOscNetInterface) DeleteNet(netId string) error {
+func (m *MockOscNetInterface) DeleteNet(ctx context.Context, netId string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteNet", netId)
+	ret := m.ctrl.Call(m, "DeleteNet", ctx, netId)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteNet indicates an expected call of DeleteNet.
-func (mr *MockOscNetInterfaceMockRecorder) DeleteNet(netId interface{}) *gomock.Call {
+func (mr *MockOscNetInterfaceMockRecorder) DeleteNet(ctx, netId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNet", reflect.TypeOf((*MockOscNetInterface)(nil).DeleteNet), netId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNet", reflect.TypeOf((*MockOscNetInterface)(nil).DeleteNet), ctx, netId)
 }
 
 // GetNet mocks base method.
-func (m *MockOscNetInterface) GetNet(netId string) (*osc.Net, error) {
+func (m *MockOscNetInterface) GetNet(ctx context.Context, netId string) (*osc.Net, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNet", netId)
+	ret := m.ctrl.Call(m, "GetNet", ctx, netId)
 	ret0, _ := ret[0].(*osc.Net)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetNet indicates an expected call of GetNet.
-func (mr *MockOscNetInterfaceMockRecorder) GetNet(netId interface{}) *gomock.Call {
+func (mr *MockOscNetInterfaceMockRecorder) GetNet(ctx, netId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNet", reflect.TypeOf((*MockOscNetInterface)(nil).GetNet), netId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNet", reflect.TypeOf((*MockOscNetInterface)(nil).GetNet), ctx, netId)
 }

--- a/cloud/services/net/mock_net/subnet_mock.go
+++ b/cloud/services/net/mock_net/subnet_mock.go
@@ -5,6 +5,7 @@
 package mock_net
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -36,60 +37,60 @@ func (m *MockOscSubnetInterface) EXPECT() *MockOscSubnetInterfaceMockRecorder {
 }
 
 // CreateSubnet mocks base method.
-func (m *MockOscSubnetInterface) CreateSubnet(spec *v1beta1.OscSubnet, netId, clusterName, subnetName string) (*osc.Subnet, error) {
+func (m *MockOscSubnetInterface) CreateSubnet(ctx context.Context, spec *v1beta1.OscSubnet, netId, clusterName, subnetName string) (*osc.Subnet, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateSubnet", spec, netId, clusterName, subnetName)
+	ret := m.ctrl.Call(m, "CreateSubnet", ctx, spec, netId, clusterName, subnetName)
 	ret0, _ := ret[0].(*osc.Subnet)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateSubnet indicates an expected call of CreateSubnet.
-func (mr *MockOscSubnetInterfaceMockRecorder) CreateSubnet(spec, netId, clusterName, subnetName interface{}) *gomock.Call {
+func (mr *MockOscSubnetInterfaceMockRecorder) CreateSubnet(ctx, spec, netId, clusterName, subnetName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSubnet", reflect.TypeOf((*MockOscSubnetInterface)(nil).CreateSubnet), spec, netId, clusterName, subnetName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSubnet", reflect.TypeOf((*MockOscSubnetInterface)(nil).CreateSubnet), ctx, spec, netId, clusterName, subnetName)
 }
 
 // DeleteSubnet mocks base method.
-func (m *MockOscSubnetInterface) DeleteSubnet(subnetId string) error {
+func (m *MockOscSubnetInterface) DeleteSubnet(ctx context.Context, subnetId string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteSubnet", subnetId)
+	ret := m.ctrl.Call(m, "DeleteSubnet", ctx, subnetId)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteSubnet indicates an expected call of DeleteSubnet.
-func (mr *MockOscSubnetInterfaceMockRecorder) DeleteSubnet(subnetId interface{}) *gomock.Call {
+func (mr *MockOscSubnetInterfaceMockRecorder) DeleteSubnet(ctx, subnetId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSubnet", reflect.TypeOf((*MockOscSubnetInterface)(nil).DeleteSubnet), subnetId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSubnet", reflect.TypeOf((*MockOscSubnetInterface)(nil).DeleteSubnet), ctx, subnetId)
 }
 
 // GetSubnet mocks base method.
-func (m *MockOscSubnetInterface) GetSubnet(subnetId string) (*osc.Subnet, error) {
+func (m *MockOscSubnetInterface) GetSubnet(ctx context.Context, subnetId string) (*osc.Subnet, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSubnet", subnetId)
+	ret := m.ctrl.Call(m, "GetSubnet", ctx, subnetId)
 	ret0, _ := ret[0].(*osc.Subnet)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSubnet indicates an expected call of GetSubnet.
-func (mr *MockOscSubnetInterfaceMockRecorder) GetSubnet(subnetId interface{}) *gomock.Call {
+func (mr *MockOscSubnetInterfaceMockRecorder) GetSubnet(ctx, subnetId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnet", reflect.TypeOf((*MockOscSubnetInterface)(nil).GetSubnet), subnetId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnet", reflect.TypeOf((*MockOscSubnetInterface)(nil).GetSubnet), ctx, subnetId)
 }
 
 // GetSubnetIdsFromNetIds mocks base method.
-func (m *MockOscSubnetInterface) GetSubnetIdsFromNetIds(netId string) ([]string, error) {
+func (m *MockOscSubnetInterface) GetSubnetIdsFromNetIds(ctx context.Context, netId string) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSubnetIdsFromNetIds", netId)
+	ret := m.ctrl.Call(m, "GetSubnetIdsFromNetIds", ctx, netId)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSubnetIdsFromNetIds indicates an expected call of GetSubnetIdsFromNetIds.
-func (mr *MockOscSubnetInterfaceMockRecorder) GetSubnetIdsFromNetIds(netId interface{}) *gomock.Call {
+func (mr *MockOscSubnetInterfaceMockRecorder) GetSubnetIdsFromNetIds(ctx, netId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnetIdsFromNetIds", reflect.TypeOf((*MockOscSubnetInterface)(nil).GetSubnetIdsFromNetIds), netId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnetIdsFromNetIds", reflect.TypeOf((*MockOscSubnetInterface)(nil).GetSubnetIdsFromNetIds), ctx, netId)
 }

--- a/cloud/services/security/mock_security/keypair_mock.go
+++ b/cloud/services/security/mock_security/keypair_mock.go
@@ -5,9 +5,11 @@
 package mock_security
 
 import (
+	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	osc "github.com/outscale/osc-sdk-go/v2"
-	reflect "reflect"
 )
 
 // MockOscKeyPairInterface is a mock of OscKeyPairInterface interface.
@@ -34,45 +36,45 @@ func (m *MockOscKeyPairInterface) EXPECT() *MockOscKeyPairInterfaceMockRecorder 
 }
 
 // CreateKeyPair mocks base method.
-func (m *MockOscKeyPairInterface) CreateKeyPair(keypairName string) (*osc.KeypairCreated, error) {
+func (m *MockOscKeyPairInterface) CreateKeyPair(ctx context.Context, keypairName string) (*osc.KeypairCreated, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateKeyPair", keypairName)
+	ret := m.ctrl.Call(m, "CreateKeyPair", ctx, keypairName)
 	ret0, _ := ret[0].(*osc.KeypairCreated)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateKeyPair indicates an expected call of CreateKeyPair.
-func (mr *MockOscKeyPairInterfaceMockRecorder) CreateKeyPair(keypairName interface{}) *gomock.Call {
+func (mr *MockOscKeyPairInterfaceMockRecorder) CreateKeyPair(ctx, keypairName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateKeyPair", reflect.TypeOf((*MockOscKeyPairInterface)(nil).CreateKeyPair), keypairName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateKeyPair", reflect.TypeOf((*MockOscKeyPairInterface)(nil).CreateKeyPair), ctx, keypairName)
 }
 
 // DeleteKeyPair mocks base method.
-func (m *MockOscKeyPairInterface) DeleteKeyPair(keypairName string) error {
+func (m *MockOscKeyPairInterface) DeleteKeyPair(ctx context.Context, keypairName string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteKeyPair", keypairName)
+	ret := m.ctrl.Call(m, "DeleteKeyPair", ctx, keypairName)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteKeyPair indicates an expected call of DeleteKeyPair.
-func (mr *MockOscKeyPairInterfaceMockRecorder) DeleteKeyPair(keypairName interface{}) *gomock.Call {
+func (mr *MockOscKeyPairInterfaceMockRecorder) DeleteKeyPair(ctx, keypairName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteKeyPair", reflect.TypeOf((*MockOscKeyPairInterface)(nil).DeleteKeyPair), keypairName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteKeyPair", reflect.TypeOf((*MockOscKeyPairInterface)(nil).DeleteKeyPair), ctx, keypairName)
 }
 
 // GetKeyPair mocks base method.
-func (m *MockOscKeyPairInterface) GetKeyPair(keyPairName string) (*osc.Keypair, error) {
+func (m *MockOscKeyPairInterface) GetKeyPair(ctx context.Context, keyPairName string) (*osc.Keypair, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetKeyPair", keyPairName)
+	ret := m.ctrl.Call(m, "GetKeyPair", ctx, keyPairName)
 	ret0, _ := ret[0].(*osc.Keypair)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetKeyPair indicates an expected call of GetKeyPair.
-func (mr *MockOscKeyPairInterfaceMockRecorder) GetKeyPair(keyPairName interface{}) *gomock.Call {
+func (mr *MockOscKeyPairInterfaceMockRecorder) GetKeyPair(ctx, keyPairName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKeyPair", reflect.TypeOf((*MockOscKeyPairInterface)(nil).GetKeyPair), keyPairName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKeyPair", reflect.TypeOf((*MockOscKeyPairInterface)(nil).GetKeyPair), ctx, keyPairName)
 }

--- a/cloud/services/security/mock_security/publicip_mock.go
+++ b/cloud/services/security/mock_security/publicip_mock.go
@@ -5,6 +5,7 @@
 package mock_security
 
 import (
+	context "context"
 	reflect "reflect"
 	time "time"
 
@@ -36,103 +37,103 @@ func (m *MockOscPublicIpInterface) EXPECT() *MockOscPublicIpInterfaceMockRecorde
 }
 
 // CheckPublicIpUnlink mocks base method.
-func (m *MockOscPublicIpInterface) CheckPublicIpUnlink(clockInsideLoop, clockLoop time.Duration, publicIpId string) error {
+func (m *MockOscPublicIpInterface) CheckPublicIpUnlink(ctx context.Context, clockInsideLoop, clockLoop time.Duration, publicIpId string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckPublicIpUnlink", clockInsideLoop, clockLoop, publicIpId)
+	ret := m.ctrl.Call(m, "CheckPublicIpUnlink", ctx, clockInsideLoop, clockLoop, publicIpId)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CheckPublicIpUnlink indicates an expected call of CheckPublicIpUnlink.
-func (mr *MockOscPublicIpInterfaceMockRecorder) CheckPublicIpUnlink(clockInsideLoop, clockLoop, publicIpId interface{}) *gomock.Call {
+func (mr *MockOscPublicIpInterfaceMockRecorder) CheckPublicIpUnlink(ctx, clockInsideLoop, clockLoop, publicIpId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckPublicIpUnlink", reflect.TypeOf((*MockOscPublicIpInterface)(nil).CheckPublicIpUnlink), clockInsideLoop, clockLoop, publicIpId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckPublicIpUnlink", reflect.TypeOf((*MockOscPublicIpInterface)(nil).CheckPublicIpUnlink), ctx, clockInsideLoop, clockLoop, publicIpId)
 }
 
 // CreatePublicIp mocks base method.
-func (m *MockOscPublicIpInterface) CreatePublicIp(publicIpName string) (*osc.PublicIp, error) {
+func (m *MockOscPublicIpInterface) CreatePublicIp(ctx context.Context, publicIpName string) (*osc.PublicIp, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreatePublicIp", publicIpName)
+	ret := m.ctrl.Call(m, "CreatePublicIp", ctx, publicIpName)
 	ret0, _ := ret[0].(*osc.PublicIp)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreatePublicIp indicates an expected call of CreatePublicIp.
-func (mr *MockOscPublicIpInterfaceMockRecorder) CreatePublicIp(publicIpName interface{}) *gomock.Call {
+func (mr *MockOscPublicIpInterfaceMockRecorder) CreatePublicIp(ctx, publicIpName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePublicIp", reflect.TypeOf((*MockOscPublicIpInterface)(nil).CreatePublicIp), publicIpName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePublicIp", reflect.TypeOf((*MockOscPublicIpInterface)(nil).CreatePublicIp), ctx, publicIpName)
 }
 
 // DeletePublicIp mocks base method.
-func (m *MockOscPublicIpInterface) DeletePublicIp(publicIpId string) error {
+func (m *MockOscPublicIpInterface) DeletePublicIp(ctx context.Context, publicIpId string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeletePublicIp", publicIpId)
+	ret := m.ctrl.Call(m, "DeletePublicIp", ctx, publicIpId)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeletePublicIp indicates an expected call of DeletePublicIp.
-func (mr *MockOscPublicIpInterfaceMockRecorder) DeletePublicIp(publicIpId interface{}) *gomock.Call {
+func (mr *MockOscPublicIpInterfaceMockRecorder) DeletePublicIp(ctx, publicIpId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePublicIp", reflect.TypeOf((*MockOscPublicIpInterface)(nil).DeletePublicIp), publicIpId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePublicIp", reflect.TypeOf((*MockOscPublicIpInterface)(nil).DeletePublicIp), ctx, publicIpId)
 }
 
 // GetPublicIp mocks base method.
-func (m *MockOscPublicIpInterface) GetPublicIp(publicIpId string) (*osc.PublicIp, error) {
+func (m *MockOscPublicIpInterface) GetPublicIp(ctx context.Context, publicIpId string) (*osc.PublicIp, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPublicIp", publicIpId)
+	ret := m.ctrl.Call(m, "GetPublicIp", ctx, publicIpId)
 	ret0, _ := ret[0].(*osc.PublicIp)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPublicIp indicates an expected call of GetPublicIp.
-func (mr *MockOscPublicIpInterfaceMockRecorder) GetPublicIp(publicIpId interface{}) *gomock.Call {
+func (mr *MockOscPublicIpInterfaceMockRecorder) GetPublicIp(ctx, publicIpId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicIp", reflect.TypeOf((*MockOscPublicIpInterface)(nil).GetPublicIp), publicIpId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicIp", reflect.TypeOf((*MockOscPublicIpInterface)(nil).GetPublicIp), ctx, publicIpId)
 }
 
 // LinkPublicIp mocks base method.
-func (m *MockOscPublicIpInterface) LinkPublicIp(publicIpId, vmId string) (string, error) {
+func (m *MockOscPublicIpInterface) LinkPublicIp(ctx context.Context, publicIpId, vmId string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LinkPublicIp", publicIpId, vmId)
+	ret := m.ctrl.Call(m, "LinkPublicIp", ctx, publicIpId, vmId)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // LinkPublicIp indicates an expected call of LinkPublicIp.
-func (mr *MockOscPublicIpInterfaceMockRecorder) LinkPublicIp(publicIpId, vmId interface{}) *gomock.Call {
+func (mr *MockOscPublicIpInterfaceMockRecorder) LinkPublicIp(ctx, publicIpId, vmId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkPublicIp", reflect.TypeOf((*MockOscPublicIpInterface)(nil).LinkPublicIp), publicIpId, vmId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkPublicIp", reflect.TypeOf((*MockOscPublicIpInterface)(nil).LinkPublicIp), ctx, publicIpId, vmId)
 }
 
 // UnlinkPublicIp mocks base method.
-func (m *MockOscPublicIpInterface) UnlinkPublicIp(linkPublicIpId string) error {
+func (m *MockOscPublicIpInterface) UnlinkPublicIp(ctx context.Context, linkPublicIpId string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnlinkPublicIp", linkPublicIpId)
+	ret := m.ctrl.Call(m, "UnlinkPublicIp", ctx, linkPublicIpId)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UnlinkPublicIp indicates an expected call of UnlinkPublicIp.
-func (mr *MockOscPublicIpInterfaceMockRecorder) UnlinkPublicIp(linkPublicIpId interface{}) *gomock.Call {
+func (mr *MockOscPublicIpInterfaceMockRecorder) UnlinkPublicIp(ctx, linkPublicIpId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnlinkPublicIp", reflect.TypeOf((*MockOscPublicIpInterface)(nil).UnlinkPublicIp), linkPublicIpId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnlinkPublicIp", reflect.TypeOf((*MockOscPublicIpInterface)(nil).UnlinkPublicIp), ctx, linkPublicIpId)
 }
 
 // ValidatePublicIpIds mocks base method.
-func (m *MockOscPublicIpInterface) ValidatePublicIpIds(publicIpIds []string) ([]string, error) {
+func (m *MockOscPublicIpInterface) ValidatePublicIpIds(ctx context.Context, publicIpIds []string) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidatePublicIpIds", publicIpIds)
+	ret := m.ctrl.Call(m, "ValidatePublicIpIds", ctx, publicIpIds)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ValidatePublicIpIds indicates an expected call of ValidatePublicIpIds.
-func (mr *MockOscPublicIpInterfaceMockRecorder) ValidatePublicIpIds(publicIpIds interface{}) *gomock.Call {
+func (mr *MockOscPublicIpInterfaceMockRecorder) ValidatePublicIpIds(ctx, publicIpIds interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidatePublicIpIds", reflect.TypeOf((*MockOscPublicIpInterface)(nil).ValidatePublicIpIds), publicIpIds)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidatePublicIpIds", reflect.TypeOf((*MockOscPublicIpInterface)(nil).ValidatePublicIpIds), ctx, publicIpIds)
 }

--- a/cloud/services/security/mock_security/route_mock.go
+++ b/cloud/services/security/mock_security/route_mock.go
@@ -5,6 +5,7 @@
 package mock_security
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -35,133 +36,133 @@ func (m *MockOscRouteTableInterface) EXPECT() *MockOscRouteTableInterfaceMockRec
 }
 
 // CreateRoute mocks base method.
-func (m *MockOscRouteTableInterface) CreateRoute(destinationIpRange, routeTableId, resourceId, resourceType string) (*osc.RouteTable, error) {
+func (m *MockOscRouteTableInterface) CreateRoute(ctx context.Context, destinationIpRange, routeTableId, resourceId, resourceType string) (*osc.RouteTable, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateRoute", destinationIpRange, routeTableId, resourceId, resourceType)
+	ret := m.ctrl.Call(m, "CreateRoute", ctx, destinationIpRange, routeTableId, resourceId, resourceType)
 	ret0, _ := ret[0].(*osc.RouteTable)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateRoute indicates an expected call of CreateRoute.
-func (mr *MockOscRouteTableInterfaceMockRecorder) CreateRoute(destinationIpRange, routeTableId, resourceId, resourceType interface{}) *gomock.Call {
+func (mr *MockOscRouteTableInterfaceMockRecorder) CreateRoute(ctx, destinationIpRange, routeTableId, resourceId, resourceType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRoute", reflect.TypeOf((*MockOscRouteTableInterface)(nil).CreateRoute), destinationIpRange, routeTableId, resourceId, resourceType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRoute", reflect.TypeOf((*MockOscRouteTableInterface)(nil).CreateRoute), ctx, destinationIpRange, routeTableId, resourceId, resourceType)
 }
 
 // CreateRouteTable mocks base method.
-func (m *MockOscRouteTableInterface) CreateRouteTable(netId, clusterName, routeTableName string) (*osc.RouteTable, error) {
+func (m *MockOscRouteTableInterface) CreateRouteTable(ctx context.Context, netId, clusterName, routeTableName string) (*osc.RouteTable, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateRouteTable", netId, clusterName, routeTableName)
+	ret := m.ctrl.Call(m, "CreateRouteTable", ctx, netId, clusterName, routeTableName)
 	ret0, _ := ret[0].(*osc.RouteTable)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateRouteTable indicates an expected call of CreateRouteTable.
-func (mr *MockOscRouteTableInterfaceMockRecorder) CreateRouteTable(netId, clusterName, routeTableName interface{}) *gomock.Call {
+func (mr *MockOscRouteTableInterfaceMockRecorder) CreateRouteTable(ctx, netId, clusterName, routeTableName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRouteTable", reflect.TypeOf((*MockOscRouteTableInterface)(nil).CreateRouteTable), netId, clusterName, routeTableName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRouteTable", reflect.TypeOf((*MockOscRouteTableInterface)(nil).CreateRouteTable), ctx, netId, clusterName, routeTableName)
 }
 
 // DeleteRoute mocks base method.
-func (m *MockOscRouteTableInterface) DeleteRoute(destinationIpRange, routeTableId string) error {
+func (m *MockOscRouteTableInterface) DeleteRoute(ctx context.Context, destinationIpRange, routeTableId string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteRoute", destinationIpRange, routeTableId)
+	ret := m.ctrl.Call(m, "DeleteRoute", ctx, destinationIpRange, routeTableId)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteRoute indicates an expected call of DeleteRoute.
-func (mr *MockOscRouteTableInterfaceMockRecorder) DeleteRoute(destinationIpRange, routeTableId interface{}) *gomock.Call {
+func (mr *MockOscRouteTableInterfaceMockRecorder) DeleteRoute(ctx, destinationIpRange, routeTableId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRoute", reflect.TypeOf((*MockOscRouteTableInterface)(nil).DeleteRoute), destinationIpRange, routeTableId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRoute", reflect.TypeOf((*MockOscRouteTableInterface)(nil).DeleteRoute), ctx, destinationIpRange, routeTableId)
 }
 
 // DeleteRouteTable mocks base method.
-func (m *MockOscRouteTableInterface) DeleteRouteTable(routeTableId string) error {
+func (m *MockOscRouteTableInterface) DeleteRouteTable(ctx context.Context, routeTableId string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteRouteTable", routeTableId)
+	ret := m.ctrl.Call(m, "DeleteRouteTable", ctx, routeTableId)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteRouteTable indicates an expected call of DeleteRouteTable.
-func (mr *MockOscRouteTableInterfaceMockRecorder) DeleteRouteTable(routeTableId interface{}) *gomock.Call {
+func (mr *MockOscRouteTableInterfaceMockRecorder) DeleteRouteTable(ctx, routeTableId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRouteTable", reflect.TypeOf((*MockOscRouteTableInterface)(nil).DeleteRouteTable), routeTableId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRouteTable", reflect.TypeOf((*MockOscRouteTableInterface)(nil).DeleteRouteTable), ctx, routeTableId)
 }
 
 // GetRouteTable mocks base method.
-func (m *MockOscRouteTableInterface) GetRouteTable(routeTableId []string) (*osc.RouteTable, error) {
+func (m *MockOscRouteTableInterface) GetRouteTable(ctx context.Context, routeTableId []string) (*osc.RouteTable, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRouteTable", routeTableId)
+	ret := m.ctrl.Call(m, "GetRouteTable", ctx, routeTableId)
 	ret0, _ := ret[0].(*osc.RouteTable)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetRouteTable indicates an expected call of GetRouteTable.
-func (mr *MockOscRouteTableInterfaceMockRecorder) GetRouteTable(routeTableId interface{}) *gomock.Call {
+func (mr *MockOscRouteTableInterfaceMockRecorder) GetRouteTable(ctx, routeTableId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRouteTable", reflect.TypeOf((*MockOscRouteTableInterface)(nil).GetRouteTable), routeTableId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRouteTable", reflect.TypeOf((*MockOscRouteTableInterface)(nil).GetRouteTable), ctx, routeTableId)
 }
 
 // GetRouteTableFromRoute mocks base method.
-func (m *MockOscRouteTableInterface) GetRouteTableFromRoute(routeTableId, resourceId, resourceType string) (*osc.RouteTable, error) {
+func (m *MockOscRouteTableInterface) GetRouteTableFromRoute(ctx context.Context, routeTableId, resourceId, resourceType string) (*osc.RouteTable, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRouteTableFromRoute", routeTableId, resourceId, resourceType)
+	ret := m.ctrl.Call(m, "GetRouteTableFromRoute", ctx, routeTableId, resourceId, resourceType)
 	ret0, _ := ret[0].(*osc.RouteTable)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetRouteTableFromRoute indicates an expected call of GetRouteTableFromRoute.
-func (mr *MockOscRouteTableInterfaceMockRecorder) GetRouteTableFromRoute(routeTableId, resourceId, resourceType interface{}) *gomock.Call {
+func (mr *MockOscRouteTableInterfaceMockRecorder) GetRouteTableFromRoute(ctx, routeTableId, resourceId, resourceType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRouteTableFromRoute", reflect.TypeOf((*MockOscRouteTableInterface)(nil).GetRouteTableFromRoute), routeTableId, resourceId, resourceType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRouteTableFromRoute", reflect.TypeOf((*MockOscRouteTableInterface)(nil).GetRouteTableFromRoute), ctx, routeTableId, resourceId, resourceType)
 }
 
 // GetRouteTableIdsFromNetIds mocks base method.
-func (m *MockOscRouteTableInterface) GetRouteTableIdsFromNetIds(netId string) ([]string, error) {
+func (m *MockOscRouteTableInterface) GetRouteTableIdsFromNetIds(ctx context.Context, netId string) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRouteTableIdsFromNetIds", netId)
+	ret := m.ctrl.Call(m, "GetRouteTableIdsFromNetIds", ctx, netId)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetRouteTableIdsFromNetIds indicates an expected call of GetRouteTableIdsFromNetIds.
-func (mr *MockOscRouteTableInterfaceMockRecorder) GetRouteTableIdsFromNetIds(netId interface{}) *gomock.Call {
+func (mr *MockOscRouteTableInterfaceMockRecorder) GetRouteTableIdsFromNetIds(ctx, netId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRouteTableIdsFromNetIds", reflect.TypeOf((*MockOscRouteTableInterface)(nil).GetRouteTableIdsFromNetIds), netId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRouteTableIdsFromNetIds", reflect.TypeOf((*MockOscRouteTableInterface)(nil).GetRouteTableIdsFromNetIds), ctx, netId)
 }
 
 // LinkRouteTable mocks base method.
-func (m *MockOscRouteTableInterface) LinkRouteTable(routeTableId, subnetId string) (string, error) {
+func (m *MockOscRouteTableInterface) LinkRouteTable(ctx context.Context, routeTableId, subnetId string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LinkRouteTable", routeTableId, subnetId)
+	ret := m.ctrl.Call(m, "LinkRouteTable", ctx, routeTableId, subnetId)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // LinkRouteTable indicates an expected call of LinkRouteTable.
-func (mr *MockOscRouteTableInterfaceMockRecorder) LinkRouteTable(routeTableId, subnetId interface{}) *gomock.Call {
+func (mr *MockOscRouteTableInterfaceMockRecorder) LinkRouteTable(ctx, routeTableId, subnetId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkRouteTable", reflect.TypeOf((*MockOscRouteTableInterface)(nil).LinkRouteTable), routeTableId, subnetId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkRouteTable", reflect.TypeOf((*MockOscRouteTableInterface)(nil).LinkRouteTable), ctx, routeTableId, subnetId)
 }
 
 // UnlinkRouteTable mocks base method.
-func (m *MockOscRouteTableInterface) UnlinkRouteTable(linkRouteTableId string) error {
+func (m *MockOscRouteTableInterface) UnlinkRouteTable(ctx context.Context, linkRouteTableId string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnlinkRouteTable", linkRouteTableId)
+	ret := m.ctrl.Call(m, "UnlinkRouteTable", ctx, linkRouteTableId)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UnlinkRouteTable indicates an expected call of UnlinkRouteTable.
-func (mr *MockOscRouteTableInterfaceMockRecorder) UnlinkRouteTable(linkRouteTableId interface{}) *gomock.Call {
+func (mr *MockOscRouteTableInterfaceMockRecorder) UnlinkRouteTable(ctx, linkRouteTableId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnlinkRouteTable", reflect.TypeOf((*MockOscRouteTableInterface)(nil).UnlinkRouteTable), linkRouteTableId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnlinkRouteTable", reflect.TypeOf((*MockOscRouteTableInterface)(nil).UnlinkRouteTable), ctx, linkRouteTableId)
 }

--- a/cloud/services/security/mock_security/securitygroup_mock.go
+++ b/cloud/services/security/mock_security/securitygroup_mock.go
@@ -5,7 +5,7 @@
 package mock_security
 
 import (
-	http "net/http"
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -36,105 +36,104 @@ func (m *MockOscSecurityGroupInterface) EXPECT() *MockOscSecurityGroupInterfaceM
 }
 
 // CreateSecurityGroup mocks base method.
-func (m *MockOscSecurityGroupInterface) CreateSecurityGroup(netId, clusterName, securityGroupName, securityGroupDescription, securityGroupTag string) (*osc.SecurityGroup, error) {
+func (m *MockOscSecurityGroupInterface) CreateSecurityGroup(ctx context.Context, netId, clusterName, securityGroupName, securityGroupDescription, securityGroupTag string) (*osc.SecurityGroup, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateSecurityGroup", netId, clusterName, securityGroupName, securityGroupDescription, securityGroupTag)
+	ret := m.ctrl.Call(m, "CreateSecurityGroup", ctx, netId, clusterName, securityGroupName, securityGroupDescription, securityGroupTag)
 	ret0, _ := ret[0].(*osc.SecurityGroup)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateSecurityGroup indicates an expected call of CreateSecurityGroup.
-func (mr *MockOscSecurityGroupInterfaceMockRecorder) CreateSecurityGroup(netId, clusterName, securityGroupName, securityGroupDescription, securityGroupTag interface{}) *gomock.Call {
+func (mr *MockOscSecurityGroupInterfaceMockRecorder) CreateSecurityGroup(ctx, netId, clusterName, securityGroupName, securityGroupDescription, securityGroupTag interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecurityGroup", reflect.TypeOf((*MockOscSecurityGroupInterface)(nil).CreateSecurityGroup), netId, clusterName, securityGroupName, securityGroupDescription, securityGroupTag)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecurityGroup", reflect.TypeOf((*MockOscSecurityGroupInterface)(nil).CreateSecurityGroup), ctx, netId, clusterName, securityGroupName, securityGroupDescription, securityGroupTag)
 }
 
 // CreateSecurityGroupRule mocks base method.
-func (m *MockOscSecurityGroupInterface) CreateSecurityGroupRule(securityGroupId, flow, ipProtocol, ipRange, securityGroupMemberId string, fromPortRange, toPortRange int32) (*osc.SecurityGroup, error) {
+func (m *MockOscSecurityGroupInterface) CreateSecurityGroupRule(ctx context.Context, securityGroupId, flow, ipProtocol, ipRange, securityGroupMemberId string, fromPortRange, toPortRange int32) (*osc.SecurityGroup, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateSecurityGroupRule", securityGroupId, flow, ipProtocol, ipRange, securityGroupMemberId, fromPortRange, toPortRange)
+	ret := m.ctrl.Call(m, "CreateSecurityGroupRule", ctx, securityGroupId, flow, ipProtocol, ipRange, securityGroupMemberId, fromPortRange, toPortRange)
 	ret0, _ := ret[0].(*osc.SecurityGroup)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateSecurityGroupRule indicates an expected call of CreateSecurityGroupRule.
-func (mr *MockOscSecurityGroupInterfaceMockRecorder) CreateSecurityGroupRule(securityGroupId, flow, ipProtocol, ipRange, securityGroupMemberId, fromPortRange, toPortRange interface{}) *gomock.Call {
+func (mr *MockOscSecurityGroupInterfaceMockRecorder) CreateSecurityGroupRule(ctx, securityGroupId, flow, ipProtocol, ipRange, securityGroupMemberId, fromPortRange, toPortRange interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecurityGroupRule", reflect.TypeOf((*MockOscSecurityGroupInterface)(nil).CreateSecurityGroupRule), securityGroupId, flow, ipProtocol, ipRange, securityGroupMemberId, fromPortRange, toPortRange)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecurityGroupRule", reflect.TypeOf((*MockOscSecurityGroupInterface)(nil).CreateSecurityGroupRule), ctx, securityGroupId, flow, ipProtocol, ipRange, securityGroupMemberId, fromPortRange, toPortRange)
 }
 
 // DeleteSecurityGroup mocks base method.
-func (m *MockOscSecurityGroupInterface) DeleteSecurityGroup(securityGroupId string) (error, *http.Response) {
+func (m *MockOscSecurityGroupInterface) DeleteSecurityGroup(ctx context.Context, securityGroupId string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteSecurityGroup", securityGroupId)
+	ret := m.ctrl.Call(m, "DeleteSecurityGroup", ctx, securityGroupId)
 	ret0, _ := ret[0].(error)
-	ret1, _ := ret[1].(*http.Response)
-	return ret0, ret1
+	return ret0
 }
 
 // DeleteSecurityGroup indicates an expected call of DeleteSecurityGroup.
-func (mr *MockOscSecurityGroupInterfaceMockRecorder) DeleteSecurityGroup(securityGroupId interface{}) *gomock.Call {
+func (mr *MockOscSecurityGroupInterfaceMockRecorder) DeleteSecurityGroup(ctx, securityGroupId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecurityGroup", reflect.TypeOf((*MockOscSecurityGroupInterface)(nil).DeleteSecurityGroup), securityGroupId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecurityGroup", reflect.TypeOf((*MockOscSecurityGroupInterface)(nil).DeleteSecurityGroup), ctx, securityGroupId)
 }
 
 // DeleteSecurityGroupRule mocks base method.
-func (m *MockOscSecurityGroupInterface) DeleteSecurityGroupRule(securityGroupId, flow, ipProtocol, ipRange, securityGroupMemberId string, fromPortRange, toPortRange int32) error {
+func (m *MockOscSecurityGroupInterface) DeleteSecurityGroupRule(ctx context.Context, securityGroupId, flow, ipProtocol, ipRange, securityGroupMemberId string, fromPortRange, toPortRange int32) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteSecurityGroupRule", securityGroupId, flow, ipProtocol, ipRange, securityGroupMemberId, fromPortRange, toPortRange)
+	ret := m.ctrl.Call(m, "DeleteSecurityGroupRule", ctx, securityGroupId, flow, ipProtocol, ipRange, securityGroupMemberId, fromPortRange, toPortRange)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteSecurityGroupRule indicates an expected call of DeleteSecurityGroupRule.
-func (mr *MockOscSecurityGroupInterfaceMockRecorder) DeleteSecurityGroupRule(securityGroupId, flow, ipProtocol, ipRange, securityGroupMemberId, fromPortRange, toPortRange interface{}) *gomock.Call {
+func (mr *MockOscSecurityGroupInterfaceMockRecorder) DeleteSecurityGroupRule(ctx, securityGroupId, flow, ipProtocol, ipRange, securityGroupMemberId, fromPortRange, toPortRange interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecurityGroupRule", reflect.TypeOf((*MockOscSecurityGroupInterface)(nil).DeleteSecurityGroupRule), securityGroupId, flow, ipProtocol, ipRange, securityGroupMemberId, fromPortRange, toPortRange)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecurityGroupRule", reflect.TypeOf((*MockOscSecurityGroupInterface)(nil).DeleteSecurityGroupRule), ctx, securityGroupId, flow, ipProtocol, ipRange, securityGroupMemberId, fromPortRange, toPortRange)
 }
 
 // GetSecurityGroup mocks base method.
-func (m *MockOscSecurityGroupInterface) GetSecurityGroup(securityGroupId string) (*osc.SecurityGroup, error) {
+func (m *MockOscSecurityGroupInterface) GetSecurityGroup(ctx context.Context, securityGroupId string) (*osc.SecurityGroup, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSecurityGroup", securityGroupId)
+	ret := m.ctrl.Call(m, "GetSecurityGroup", ctx, securityGroupId)
 	ret0, _ := ret[0].(*osc.SecurityGroup)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSecurityGroup indicates an expected call of GetSecurityGroup.
-func (mr *MockOscSecurityGroupInterfaceMockRecorder) GetSecurityGroup(securityGroupId interface{}) *gomock.Call {
+func (mr *MockOscSecurityGroupInterfaceMockRecorder) GetSecurityGroup(ctx, securityGroupId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecurityGroup", reflect.TypeOf((*MockOscSecurityGroupInterface)(nil).GetSecurityGroup), securityGroupId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecurityGroup", reflect.TypeOf((*MockOscSecurityGroupInterface)(nil).GetSecurityGroup), ctx, securityGroupId)
 }
 
 // GetSecurityGroupFromSecurityGroupRule mocks base method.
-func (m *MockOscSecurityGroupInterface) GetSecurityGroupFromSecurityGroupRule(securityGroupId, Flow, IpProtocols, IpRanges, securityGroupMemberId string, FromPortRanges, ToPortRanges int32) (*osc.SecurityGroup, error) {
+func (m *MockOscSecurityGroupInterface) GetSecurityGroupFromSecurityGroupRule(ctx context.Context, securityGroupId, Flow, IpProtocols, IpRanges, securityGroupMemberId string, FromPortRanges, ToPortRanges int32) (*osc.SecurityGroup, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSecurityGroupFromSecurityGroupRule", securityGroupId, Flow, IpProtocols, IpRanges, securityGroupMemberId, FromPortRanges, ToPortRanges)
+	ret := m.ctrl.Call(m, "GetSecurityGroupFromSecurityGroupRule", ctx, securityGroupId, Flow, IpProtocols, IpRanges, securityGroupMemberId, FromPortRanges, ToPortRanges)
 	ret0, _ := ret[0].(*osc.SecurityGroup)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSecurityGroupFromSecurityGroupRule indicates an expected call of GetSecurityGroupFromSecurityGroupRule.
-func (mr *MockOscSecurityGroupInterfaceMockRecorder) GetSecurityGroupFromSecurityGroupRule(securityGroupId, Flow, IpProtocols, IpRanges, securityGroupMemberId, FromPortRanges, ToPortRanges interface{}) *gomock.Call {
+func (mr *MockOscSecurityGroupInterfaceMockRecorder) GetSecurityGroupFromSecurityGroupRule(ctx, securityGroupId, Flow, IpProtocols, IpRanges, securityGroupMemberId, FromPortRanges, ToPortRanges interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecurityGroupFromSecurityGroupRule", reflect.TypeOf((*MockOscSecurityGroupInterface)(nil).GetSecurityGroupFromSecurityGroupRule), securityGroupId, Flow, IpProtocols, IpRanges, securityGroupMemberId, FromPortRanges, ToPortRanges)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecurityGroupFromSecurityGroupRule", reflect.TypeOf((*MockOscSecurityGroupInterface)(nil).GetSecurityGroupFromSecurityGroupRule), ctx, securityGroupId, Flow, IpProtocols, IpRanges, securityGroupMemberId, FromPortRanges, ToPortRanges)
 }
 
 // GetSecurityGroupIdsFromNetIds mocks base method.
-func (m *MockOscSecurityGroupInterface) GetSecurityGroupIdsFromNetIds(netId string) ([]string, error) {
+func (m *MockOscSecurityGroupInterface) GetSecurityGroupIdsFromNetIds(ctx context.Context, netId string) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSecurityGroupIdsFromNetIds", netId)
+	ret := m.ctrl.Call(m, "GetSecurityGroupIdsFromNetIds", ctx, netId)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSecurityGroupIdsFromNetIds indicates an expected call of GetSecurityGroupIdsFromNetIds.
-func (mr *MockOscSecurityGroupInterfaceMockRecorder) GetSecurityGroupIdsFromNetIds(netId interface{}) *gomock.Call {
+func (mr *MockOscSecurityGroupInterfaceMockRecorder) GetSecurityGroupIdsFromNetIds(ctx, netId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecurityGroupIdsFromNetIds", reflect.TypeOf((*MockOscSecurityGroupInterface)(nil).GetSecurityGroupIdsFromNetIds), netId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecurityGroupIdsFromNetIds", reflect.TypeOf((*MockOscSecurityGroupInterface)(nil).GetSecurityGroupIdsFromNetIds), ctx, netId)
 }

--- a/cloud/services/service/mock_service/loadbalancer_mock.go
+++ b/cloud/services/service/mock_service/loadbalancer_mock.go
@@ -5,6 +5,7 @@
 package mock_service
 
 import (
+	context "context"
 	reflect "reflect"
 	time "time"
 
@@ -37,145 +38,145 @@ func (m *MockOscLoadBalancerInterface) EXPECT() *MockOscLoadBalancerInterfaceMoc
 }
 
 // CheckLoadBalancerDeregisterVm mocks base method.
-func (m *MockOscLoadBalancerInterface) CheckLoadBalancerDeregisterVm(clockInsideLoop, clockLoop time.Duration, spec *v1beta1.OscLoadBalancer) error {
+func (m *MockOscLoadBalancerInterface) CheckLoadBalancerDeregisterVm(ctx context.Context, clockInsideLoop, clockLoop time.Duration, spec *v1beta1.OscLoadBalancer) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckLoadBalancerDeregisterVm", clockInsideLoop, clockLoop, spec)
+	ret := m.ctrl.Call(m, "CheckLoadBalancerDeregisterVm", ctx, clockInsideLoop, clockLoop, spec)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CheckLoadBalancerDeregisterVm indicates an expected call of CheckLoadBalancerDeregisterVm.
-func (mr *MockOscLoadBalancerInterfaceMockRecorder) CheckLoadBalancerDeregisterVm(clockInsideLoop, clockLoop, spec interface{}) *gomock.Call {
+func (mr *MockOscLoadBalancerInterfaceMockRecorder) CheckLoadBalancerDeregisterVm(ctx, clockInsideLoop, clockLoop, spec interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckLoadBalancerDeregisterVm", reflect.TypeOf((*MockOscLoadBalancerInterface)(nil).CheckLoadBalancerDeregisterVm), clockInsideLoop, clockLoop, spec)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckLoadBalancerDeregisterVm", reflect.TypeOf((*MockOscLoadBalancerInterface)(nil).CheckLoadBalancerDeregisterVm), ctx, clockInsideLoop, clockLoop, spec)
 }
 
 // ConfigureHealthCheck mocks base method.
-func (m *MockOscLoadBalancerInterface) ConfigureHealthCheck(spec *v1beta1.OscLoadBalancer) (*osc.LoadBalancer, error) {
+func (m *MockOscLoadBalancerInterface) ConfigureHealthCheck(ctx context.Context, spec *v1beta1.OscLoadBalancer) (*osc.LoadBalancer, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConfigureHealthCheck", spec)
+	ret := m.ctrl.Call(m, "ConfigureHealthCheck", ctx, spec)
 	ret0, _ := ret[0].(*osc.LoadBalancer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConfigureHealthCheck indicates an expected call of ConfigureHealthCheck.
-func (mr *MockOscLoadBalancerInterfaceMockRecorder) ConfigureHealthCheck(spec interface{}) *gomock.Call {
+func (mr *MockOscLoadBalancerInterfaceMockRecorder) ConfigureHealthCheck(ctx, spec interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigureHealthCheck", reflect.TypeOf((*MockOscLoadBalancerInterface)(nil).ConfigureHealthCheck), spec)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigureHealthCheck", reflect.TypeOf((*MockOscLoadBalancerInterface)(nil).ConfigureHealthCheck), ctx, spec)
 }
 
 // CreateLoadBalancer mocks base method.
-func (m *MockOscLoadBalancerInterface) CreateLoadBalancer(spec *v1beta1.OscLoadBalancer, subnetId, securityGroupId string) (*osc.LoadBalancer, error) {
+func (m *MockOscLoadBalancerInterface) CreateLoadBalancer(ctx context.Context, spec *v1beta1.OscLoadBalancer, subnetId, securityGroupId string) (*osc.LoadBalancer, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateLoadBalancer", spec, subnetId, securityGroupId)
+	ret := m.ctrl.Call(m, "CreateLoadBalancer", ctx, spec, subnetId, securityGroupId)
 	ret0, _ := ret[0].(*osc.LoadBalancer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateLoadBalancer indicates an expected call of CreateLoadBalancer.
-func (mr *MockOscLoadBalancerInterfaceMockRecorder) CreateLoadBalancer(spec, subnetId, securityGroupId interface{}) *gomock.Call {
+func (mr *MockOscLoadBalancerInterfaceMockRecorder) CreateLoadBalancer(ctx, spec, subnetId, securityGroupId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLoadBalancer", reflect.TypeOf((*MockOscLoadBalancerInterface)(nil).CreateLoadBalancer), spec, subnetId, securityGroupId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLoadBalancer", reflect.TypeOf((*MockOscLoadBalancerInterface)(nil).CreateLoadBalancer), ctx, spec, subnetId, securityGroupId)
 }
 
 // CreateLoadBalancerTag mocks base method.
-func (m *MockOscLoadBalancerInterface) CreateLoadBalancerTag(spec *v1beta1.OscLoadBalancer, loadBalancerTag osc.ResourceTag) error {
+func (m *MockOscLoadBalancerInterface) CreateLoadBalancerTag(ctx context.Context, spec *v1beta1.OscLoadBalancer, loadBalancerTag osc.ResourceTag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateLoadBalancerTag", spec, loadBalancerTag)
+	ret := m.ctrl.Call(m, "CreateLoadBalancerTag", ctx, spec, loadBalancerTag)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateLoadBalancerTag indicates an expected call of CreateLoadBalancerTag.
-func (mr *MockOscLoadBalancerInterfaceMockRecorder) CreateLoadBalancerTag(spec, loadBalancerTag interface{}) *gomock.Call {
+func (mr *MockOscLoadBalancerInterfaceMockRecorder) CreateLoadBalancerTag(ctx, spec, loadBalancerTag interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLoadBalancerTag", reflect.TypeOf((*MockOscLoadBalancerInterface)(nil).CreateLoadBalancerTag), spec, loadBalancerTag)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLoadBalancerTag", reflect.TypeOf((*MockOscLoadBalancerInterface)(nil).CreateLoadBalancerTag), ctx, spec, loadBalancerTag)
 }
 
 // DeleteLoadBalancer mocks base method.
-func (m *MockOscLoadBalancerInterface) DeleteLoadBalancer(spec *v1beta1.OscLoadBalancer) error {
+func (m *MockOscLoadBalancerInterface) DeleteLoadBalancer(ctx context.Context, spec *v1beta1.OscLoadBalancer) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteLoadBalancer", spec)
+	ret := m.ctrl.Call(m, "DeleteLoadBalancer", ctx, spec)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteLoadBalancer indicates an expected call of DeleteLoadBalancer.
-func (mr *MockOscLoadBalancerInterfaceMockRecorder) DeleteLoadBalancer(spec interface{}) *gomock.Call {
+func (mr *MockOscLoadBalancerInterfaceMockRecorder) DeleteLoadBalancer(ctx, spec interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLoadBalancer", reflect.TypeOf((*MockOscLoadBalancerInterface)(nil).DeleteLoadBalancer), spec)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLoadBalancer", reflect.TypeOf((*MockOscLoadBalancerInterface)(nil).DeleteLoadBalancer), ctx, spec)
 }
 
 // DeleteLoadBalancerTag mocks base method.
-func (m *MockOscLoadBalancerInterface) DeleteLoadBalancerTag(spec *v1beta1.OscLoadBalancer, loadBalancerTag osc.ResourceLoadBalancerTag) error {
+func (m *MockOscLoadBalancerInterface) DeleteLoadBalancerTag(ctx context.Context, spec *v1beta1.OscLoadBalancer, loadBalancerTag osc.ResourceLoadBalancerTag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteLoadBalancerTag", spec, loadBalancerTag)
+	ret := m.ctrl.Call(m, "DeleteLoadBalancerTag", ctx, spec, loadBalancerTag)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteLoadBalancerTag indicates an expected call of DeleteLoadBalancerTag.
-func (mr *MockOscLoadBalancerInterfaceMockRecorder) DeleteLoadBalancerTag(spec, loadBalancerTag interface{}) *gomock.Call {
+func (mr *MockOscLoadBalancerInterfaceMockRecorder) DeleteLoadBalancerTag(ctx, spec, loadBalancerTag interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLoadBalancerTag", reflect.TypeOf((*MockOscLoadBalancerInterface)(nil).DeleteLoadBalancerTag), spec, loadBalancerTag)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLoadBalancerTag", reflect.TypeOf((*MockOscLoadBalancerInterface)(nil).DeleteLoadBalancerTag), ctx, spec, loadBalancerTag)
 }
 
 // GetLoadBalancer mocks base method.
-func (m *MockOscLoadBalancerInterface) GetLoadBalancer(spec *v1beta1.OscLoadBalancer) (*osc.LoadBalancer, error) {
+func (m *MockOscLoadBalancerInterface) GetLoadBalancer(ctx context.Context, spec *v1beta1.OscLoadBalancer) (*osc.LoadBalancer, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLoadBalancer", spec)
+	ret := m.ctrl.Call(m, "GetLoadBalancer", ctx, spec)
 	ret0, _ := ret[0].(*osc.LoadBalancer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetLoadBalancer indicates an expected call of GetLoadBalancer.
-func (mr *MockOscLoadBalancerInterfaceMockRecorder) GetLoadBalancer(spec interface{}) *gomock.Call {
+func (mr *MockOscLoadBalancerInterfaceMockRecorder) GetLoadBalancer(ctx, spec interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLoadBalancer", reflect.TypeOf((*MockOscLoadBalancerInterface)(nil).GetLoadBalancer), spec)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLoadBalancer", reflect.TypeOf((*MockOscLoadBalancerInterface)(nil).GetLoadBalancer), ctx, spec)
 }
 
 // GetLoadBalancerTag mocks base method.
-func (m *MockOscLoadBalancerInterface) GetLoadBalancerTag(spec *v1beta1.OscLoadBalancer) (*osc.LoadBalancerTag, error) {
+func (m *MockOscLoadBalancerInterface) GetLoadBalancerTag(ctx context.Context, spec *v1beta1.OscLoadBalancer) (*osc.LoadBalancerTag, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLoadBalancerTag", spec)
+	ret := m.ctrl.Call(m, "GetLoadBalancerTag", ctx, spec)
 	ret0, _ := ret[0].(*osc.LoadBalancerTag)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetLoadBalancerTag indicates an expected call of GetLoadBalancerTag.
-func (mr *MockOscLoadBalancerInterfaceMockRecorder) GetLoadBalancerTag(spec interface{}) *gomock.Call {
+func (mr *MockOscLoadBalancerInterfaceMockRecorder) GetLoadBalancerTag(ctx, spec interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLoadBalancerTag", reflect.TypeOf((*MockOscLoadBalancerInterface)(nil).GetLoadBalancerTag), spec)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLoadBalancerTag", reflect.TypeOf((*MockOscLoadBalancerInterface)(nil).GetLoadBalancerTag), ctx, spec)
 }
 
 // LinkLoadBalancerBackendMachines mocks base method.
-func (m *MockOscLoadBalancerInterface) LinkLoadBalancerBackendMachines(vmIds []string, loadBalancerName string) error {
+func (m *MockOscLoadBalancerInterface) LinkLoadBalancerBackendMachines(ctx context.Context, vmIds []string, loadBalancerName string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LinkLoadBalancerBackendMachines", vmIds, loadBalancerName)
+	ret := m.ctrl.Call(m, "LinkLoadBalancerBackendMachines", ctx, vmIds, loadBalancerName)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // LinkLoadBalancerBackendMachines indicates an expected call of LinkLoadBalancerBackendMachines.
-func (mr *MockOscLoadBalancerInterfaceMockRecorder) LinkLoadBalancerBackendMachines(vmIds, loadBalancerName interface{}) *gomock.Call {
+func (mr *MockOscLoadBalancerInterfaceMockRecorder) LinkLoadBalancerBackendMachines(ctx, vmIds, loadBalancerName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkLoadBalancerBackendMachines", reflect.TypeOf((*MockOscLoadBalancerInterface)(nil).LinkLoadBalancerBackendMachines), vmIds, loadBalancerName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkLoadBalancerBackendMachines", reflect.TypeOf((*MockOscLoadBalancerInterface)(nil).LinkLoadBalancerBackendMachines), ctx, vmIds, loadBalancerName)
 }
 
 // UnlinkLoadBalancerBackendMachines mocks base method.
-func (m *MockOscLoadBalancerInterface) UnlinkLoadBalancerBackendMachines(vmIds []string, loadBalancerName string) error {
+func (m *MockOscLoadBalancerInterface) UnlinkLoadBalancerBackendMachines(ctx context.Context, vmIds []string, loadBalancerName string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnlinkLoadBalancerBackendMachines", vmIds, loadBalancerName)
+	ret := m.ctrl.Call(m, "UnlinkLoadBalancerBackendMachines", ctx, vmIds, loadBalancerName)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UnlinkLoadBalancerBackendMachines indicates an expected call of UnlinkLoadBalancerBackendMachines.
-func (mr *MockOscLoadBalancerInterfaceMockRecorder) UnlinkLoadBalancerBackendMachines(vmIds, loadBalancerName interface{}) *gomock.Call {
+func (mr *MockOscLoadBalancerInterfaceMockRecorder) UnlinkLoadBalancerBackendMachines(ctx, vmIds, loadBalancerName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnlinkLoadBalancerBackendMachines", reflect.TypeOf((*MockOscLoadBalancerInterface)(nil).UnlinkLoadBalancerBackendMachines), vmIds, loadBalancerName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnlinkLoadBalancerBackendMachines", reflect.TypeOf((*MockOscLoadBalancerInterface)(nil).UnlinkLoadBalancerBackendMachines), ctx, vmIds, loadBalancerName)
 }

--- a/cloud/services/storage/mock_storage/volume_mock.go
+++ b/cloud/services/storage/mock_storage/volume_mock.go
@@ -5,6 +5,7 @@
 package mock_storage
 
 import (
+	context "context"
 	reflect "reflect"
 	time "time"
 
@@ -37,102 +38,102 @@ func (m *MockOscVolumeInterface) EXPECT() *MockOscVolumeInterfaceMockRecorder {
 }
 
 // CheckVolumeState mocks base method.
-func (m *MockOscVolumeInterface) CheckVolumeState(clockInsideLoop, clockLoop time.Duration, state, volumeId string) error {
+func (m *MockOscVolumeInterface) CheckVolumeState(ctx context.Context, clockInsideLoop, clockLoop time.Duration, state, volumeId string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckVolumeState", clockInsideLoop, clockLoop, state, volumeId)
+	ret := m.ctrl.Call(m, "CheckVolumeState", ctx, clockInsideLoop, clockLoop, state, volumeId)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CheckVolumeState indicates an expected call of CheckVolumeState.
-func (mr *MockOscVolumeInterfaceMockRecorder) CheckVolumeState(clockInsideLoop, clockLoop, state, volumeId interface{}) *gomock.Call {
+func (mr *MockOscVolumeInterfaceMockRecorder) CheckVolumeState(ctx, clockInsideLoop, clockLoop, state, volumeId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckVolumeState", reflect.TypeOf((*MockOscVolumeInterface)(nil).CheckVolumeState), clockInsideLoop, clockLoop, state, volumeId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckVolumeState", reflect.TypeOf((*MockOscVolumeInterface)(nil).CheckVolumeState), ctx, clockInsideLoop, clockLoop, state, volumeId)
 }
 
 // CreateVolume mocks base method.
-func (m *MockOscVolumeInterface) CreateVolume(spec *v1beta1.OscVolume, volumeName string) (*osc.Volume, error) {
+func (m *MockOscVolumeInterface) CreateVolume(ctx context.Context, spec *v1beta1.OscVolume, volumeName string) (*osc.Volume, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateVolume", spec, volumeName)
+	ret := m.ctrl.Call(m, "CreateVolume", ctx, spec, volumeName)
 	ret0, _ := ret[0].(*osc.Volume)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateVolume indicates an expected call of CreateVolume.
-func (mr *MockOscVolumeInterfaceMockRecorder) CreateVolume(spec, volumeName interface{}) *gomock.Call {
+func (mr *MockOscVolumeInterfaceMockRecorder) CreateVolume(ctx, spec, volumeName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVolume", reflect.TypeOf((*MockOscVolumeInterface)(nil).CreateVolume), spec, volumeName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVolume", reflect.TypeOf((*MockOscVolumeInterface)(nil).CreateVolume), ctx, spec, volumeName)
 }
 
 // DeleteVolume mocks base method.
-func (m *MockOscVolumeInterface) DeleteVolume(volumeId string) error {
+func (m *MockOscVolumeInterface) DeleteVolume(ctx context.Context, volumeId string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteVolume", volumeId)
+	ret := m.ctrl.Call(m, "DeleteVolume", ctx, volumeId)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteVolume indicates an expected call of DeleteVolume.
-func (mr *MockOscVolumeInterfaceMockRecorder) DeleteVolume(volumeId interface{}) *gomock.Call {
+func (mr *MockOscVolumeInterfaceMockRecorder) DeleteVolume(ctx, volumeId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVolume", reflect.TypeOf((*MockOscVolumeInterface)(nil).DeleteVolume), volumeId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVolume", reflect.TypeOf((*MockOscVolumeInterface)(nil).DeleteVolume), ctx, volumeId)
 }
 
 // GetVolume mocks base method.
-func (m *MockOscVolumeInterface) GetVolume(volumeId string) (*osc.Volume, error) {
+func (m *MockOscVolumeInterface) GetVolume(ctx context.Context, volumeId string) (*osc.Volume, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetVolume", volumeId)
+	ret := m.ctrl.Call(m, "GetVolume", ctx, volumeId)
 	ret0, _ := ret[0].(*osc.Volume)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetVolume indicates an expected call of GetVolume.
-func (mr *MockOscVolumeInterfaceMockRecorder) GetVolume(volumeId interface{}) *gomock.Call {
+func (mr *MockOscVolumeInterfaceMockRecorder) GetVolume(ctx, volumeId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVolume", reflect.TypeOf((*MockOscVolumeInterface)(nil).GetVolume), volumeId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVolume", reflect.TypeOf((*MockOscVolumeInterface)(nil).GetVolume), ctx, volumeId)
 }
 
 // LinkVolume mocks base method.
-func (m *MockOscVolumeInterface) LinkVolume(volumeId, vmId, deviceName string) error {
+func (m *MockOscVolumeInterface) LinkVolume(ctx context.Context, volumeId, vmId, deviceName string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LinkVolume", volumeId, vmId, deviceName)
+	ret := m.ctrl.Call(m, "LinkVolume", ctx, volumeId, vmId, deviceName)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // LinkVolume indicates an expected call of LinkVolume.
-func (mr *MockOscVolumeInterfaceMockRecorder) LinkVolume(volumeId, vmId, deviceName interface{}) *gomock.Call {
+func (mr *MockOscVolumeInterfaceMockRecorder) LinkVolume(ctx, volumeId, vmId, deviceName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkVolume", reflect.TypeOf((*MockOscVolumeInterface)(nil).LinkVolume), volumeId, vmId, deviceName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkVolume", reflect.TypeOf((*MockOscVolumeInterface)(nil).LinkVolume), ctx, volumeId, vmId, deviceName)
 }
 
 // UnlinkVolume mocks base method.
-func (m *MockOscVolumeInterface) UnlinkVolume(volumeId string) error {
+func (m *MockOscVolumeInterface) UnlinkVolume(ctx context.Context, volumeId string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnlinkVolume", volumeId)
+	ret := m.ctrl.Call(m, "UnlinkVolume", ctx, volumeId)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UnlinkVolume indicates an expected call of UnlinkVolume.
-func (mr *MockOscVolumeInterfaceMockRecorder) UnlinkVolume(volumeId interface{}) *gomock.Call {
+func (mr *MockOscVolumeInterfaceMockRecorder) UnlinkVolume(ctx, volumeId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnlinkVolume", reflect.TypeOf((*MockOscVolumeInterface)(nil).UnlinkVolume), volumeId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnlinkVolume", reflect.TypeOf((*MockOscVolumeInterface)(nil).UnlinkVolume), ctx, volumeId)
 }
 
 // ValidateVolumeIds mocks base method.
-func (m *MockOscVolumeInterface) ValidateVolumeIds(volumeIds []string) ([]string, error) {
+func (m *MockOscVolumeInterface) ValidateVolumeIds(ctx context.Context, volumeIds []string) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateVolumeIds", volumeIds)
+	ret := m.ctrl.Call(m, "ValidateVolumeIds", ctx, volumeIds)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ValidateVolumeIds indicates an expected call of ValidateVolumeIds.
-func (mr *MockOscVolumeInterfaceMockRecorder) ValidateVolumeIds(volumeIds interface{}) *gomock.Call {
+func (mr *MockOscVolumeInterfaceMockRecorder) ValidateVolumeIds(ctx, volumeIds interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateVolumeIds", reflect.TypeOf((*MockOscVolumeInterface)(nil).ValidateVolumeIds), volumeIds)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateVolumeIds", reflect.TypeOf((*MockOscVolumeInterface)(nil).ValidateVolumeIds), ctx, volumeIds)
 }

--- a/cloud/tag/mock_tag/tag_mock.go
+++ b/cloud/tag/mock_tag/tag_mock.go
@@ -5,6 +5,7 @@
 package mock_tag
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -35,16 +36,16 @@ func (m *MockOscTagInterface) EXPECT() *MockOscTagInterfaceMockRecorder {
 }
 
 // ReadTag mocks base method.
-func (m *MockOscTagInterface) ReadTag(tagKey, tagValue string) (*osc.Tag, error) {
+func (m *MockOscTagInterface) ReadTag(ctx context.Context, tagKey, tagValue string) (*osc.Tag, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadTag", tagKey, tagValue)
+	ret := m.ctrl.Call(m, "ReadTag", ctx, tagKey, tagValue)
 	ret0, _ := ret[0].(*osc.Tag)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadTag indicates an expected call of ReadTag.
-func (mr *MockOscTagInterfaceMockRecorder) ReadTag(tagKey, tagValue interface{}) *gomock.Call {
+func (mr *MockOscTagInterfaceMockRecorder) ReadTag(ctx, tagKey, tagValue interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadTag", reflect.TypeOf((*MockOscTagInterface)(nil).ReadTag), tagKey, tagValue)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadTag", reflect.TypeOf((*MockOscTagInterface)(nil).ReadTag), ctx, tagKey, tagValue)
 }

--- a/cloud/utils/logging.go
+++ b/cloud/utils/logging.go
@@ -1,0 +1,46 @@
+package utils
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	"k8s.io/klog/v2"
+)
+
+const maxResponseLength = 500
+
+func clean(buf []byte) string {
+	return strings.ReplaceAll(string(buf), `"`, ``)
+}
+
+func truncatedBody(httpResp *http.Response) string {
+	body, err := io.ReadAll(httpResp.Body)
+	if err == nil {
+		str := []rune(clean(body))
+		if len(str) > maxResponseLength {
+			return string(str[:maxResponseLength/2]) + " [truncated] " + string(str[len(str)-maxResponseLength/2:])
+		}
+		return string(str)
+	}
+	return "(unable to fetch body)"
+}
+
+func LogAPICall(ctx context.Context, call string, request any, httpResp *http.Response, err error) {
+	logger := klog.FromContext(ctx).WithCallDepth(1)
+	if logger.V(5).Enabled() {
+		buf, _ := json.Marshal(request)
+		logger.Info("OAPI request: "+clean(buf), "OAPI", call)
+	}
+	switch {
+	case err != nil && httpResp == nil:
+		logger.V(3).Error(err, "OAPI error", "OAPI", call)
+	case httpResp == nil:
+	case httpResp.StatusCode > 299 && logger.V(3).Enabled():
+		logger.Info("OAPI error response: "+truncatedBody(httpResp), "OAPI", call, "http_status", httpResp.Status)
+	case logger.V(5).Enabled(): // no error
+		logger.Info("OAPI response: "+truncatedBody(httpResp), "OAPI", call)
+	}
+}

--- a/controllers/osccluster_internetservice_controller_unit_test.go
+++ b/controllers/osccluster_internetservice_controller_unit_test.go
@@ -195,7 +195,7 @@ func TestReconcileInternetServiceLink(t *testing.T) {
 			expCreateInternetServiceErr:    nil,
 			expReadTagErr:                  nil,
 			expLinkInternetServiceErr:      errors.New("LinkInternetService generic error"),
-			expReconcileInternetServiceErr: errors.New("LinkInternetService generic error Can not link internetService with net for Osccluster test-system/test-osc"),
+			expReconcileInternetServiceErr: errors.New("cannot link internetService: LinkInternetService generic error"),
 		},
 	}
 	for _, istc := range internetServiceTestCases {
@@ -221,28 +221,28 @@ func TestReconcileInternetServiceLink(t *testing.T) {
 			if istc.expTagFound {
 				mockOscTagInterface.
 					EXPECT().
-					ReadTag(gomock.Eq("Name"), gomock.Eq(internetServiceName)).
+					ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(internetServiceName)).
 					Return(&tag, istc.expReadTagErr)
 			} else {
 				mockOscTagInterface.
 					EXPECT().
-					ReadTag(gomock.Eq("Name"), gomock.Eq(internetServiceName)).
+					ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(internetServiceName)).
 					Return(nil, istc.expReadTagErr)
 			}
 			if istc.expCreateInternetServiceFound {
 				mockOscInternetServiceInterface.
 					EXPECT().
-					CreateInternetService(gomock.Eq(internetServiceName)).
+					CreateInternetService(gomock.Any(), gomock.Eq(internetServiceName)).
 					Return(internetService.InternetService, istc.expCreateInternetServiceErr)
 			} else {
 				mockOscInternetServiceInterface.
 					EXPECT().
-					CreateInternetService(gomock.Eq(internetServiceName)).
+					CreateInternetService(gomock.Any(), gomock.Eq(internetServiceName)).
 					Return(nil, istc.expCreateInternetServiceErr)
 			}
 			mockOscInternetServiceInterface.
 				EXPECT().
-				LinkInternetService(gomock.Eq(internetServiceId), gomock.Eq(netId)).
+				LinkInternetService(gomock.Any(), gomock.Eq(internetServiceId), gomock.Eq(netId)).
 				Return(istc.expLinkInternetServiceErr)
 			reconcileInternetService, err := reconcileInternetService(ctx, clusterScope, mockOscInternetServiceInterface, mockOscTagInterface)
 			if istc.expReconcileInternetServiceErr != nil {
@@ -300,26 +300,26 @@ func TestReconcileInternetServiceDelete(t *testing.T) {
 			if istc.expTagFound {
 				mockOscTagInterface.
 					EXPECT().
-					ReadTag(gomock.Eq("Name"), gomock.Eq(internetServiceName)).
+					ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(internetServiceName)).
 					Return(&tag, istc.expReadTagErr)
 			} else {
 				mockOscTagInterface.
 					EXPECT().
-					ReadTag(gomock.Eq("Name"), gomock.Eq(internetServiceName)).
+					ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(internetServiceName)).
 					Return(nil, istc.expReadTagErr)
 			}
 			mockOscInternetServiceInterface.
 				EXPECT().
-				GetInternetService(gomock.Eq(internetServiceId)).
+				GetInternetService(gomock.Any(), gomock.Eq(internetServiceId)).
 				Return(nil, istc.expDescribeInternetServiceErr)
 			mockOscInternetServiceInterface.
 				EXPECT().
-				CreateInternetService(gomock.Eq(internetServiceName)).
+				CreateInternetService(gomock.Any(), gomock.Eq(internetServiceName)).
 				Return(internetService.InternetService, istc.expCreateInternetServiceErr)
 
 			mockOscInternetServiceInterface.
 				EXPECT().
-				LinkInternetService(gomock.Eq(internetServiceId), gomock.Eq(netId)).
+				LinkInternetService(gomock.Any(), gomock.Eq(internetServiceId), gomock.Eq(netId)).
 				Return(istc.expLinkInternetServiceErr)
 
 			reconcileInternetService, err := reconcileInternetService(ctx, clusterScope, mockOscInternetServiceInterface, mockOscTagInterface)
@@ -377,17 +377,17 @@ func TestReconcileDeleteInternetServiceDeleteWithoutSpec(t *testing.T) {
 			readInternetService := *readInternetServices.InternetServices
 			mockOscInternetServiceInterface.
 				EXPECT().
-				GetInternetService(gomock.Eq(internetServiceId)).
+				GetInternetService(gomock.Any(), gomock.Eq(internetServiceId)).
 				Return(&readInternetService[0], istc.expDescribeInternetServiceErr)
 
 			mockOscInternetServiceInterface.
 				EXPECT().
-				UnlinkInternetService(gomock.Eq(internetServiceId), gomock.Eq(netId)).
+				UnlinkInternetService(gomock.Any(), gomock.Eq(internetServiceId), gomock.Eq(netId)).
 				Return(istc.expUnlinkInternetServiceErr)
 
 			mockOscInternetServiceInterface.
 				EXPECT().
-				DeleteInternetService(gomock.Eq(internetServiceId)).
+				DeleteInternetService(gomock.Any(), gomock.Eq(internetServiceId)).
 				Return(istc.expDeleteInternetServiceErr)
 
 			reconcileDeleteInternetService, err := reconcileDeleteInternetService(ctx, clusterScope, mockOscInternetServiceInterface)
@@ -452,12 +452,12 @@ func TestReconcileInternetServiceGet(t *testing.T) {
 			if istc.expTagFound {
 				mockOscTagInterface.
 					EXPECT().
-					ReadTag(gomock.Eq("Name"), gomock.Eq(internetServiceName)).
+					ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(internetServiceName)).
 					Return(&tag, istc.expReadTagErr)
 			} else {
 				mockOscTagInterface.
 					EXPECT().
-					ReadTag(gomock.Eq("Name"), gomock.Eq(internetServiceName)).
+					ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(internetServiceName)).
 					Return(nil, istc.expReadTagErr)
 			}
 
@@ -478,12 +478,12 @@ func TestReconcileInternetServiceGet(t *testing.T) {
 			if istc.expInternetServiceFound {
 				mockOscInternetServiceInterface.
 					EXPECT().
-					GetInternetService(gomock.Eq(internetServiceId)).
+					GetInternetService(gomock.Any(), gomock.Eq(internetServiceId)).
 					Return(&readInternetService[0], istc.expDescribeInternetServiceErr)
 			} else {
 				mockOscInternetServiceInterface.
 					EXPECT().
-					GetInternetService(gomock.Eq(internetServiceId)).
+					GetInternetService(gomock.Any(), gomock.Eq(internetServiceId)).
 					Return(nil, istc.expDescribeInternetServiceErr)
 			}
 
@@ -514,7 +514,7 @@ func TestReconcileInternetServiceCreate(t *testing.T) {
 			expTagFound:                    false,
 			expCreateInternetServiceErr:    errors.New("CreateInternetService generic error"),
 			expReadTagErr:                  nil,
-			expReconcileInternetServiceErr: errors.New("CreateInternetService generic error Can not create internetservice for Osccluster test-system/test-osc"),
+			expReconcileInternetServiceErr: errors.New("cannot create internetservice: CreateInternetService generic error"),
 		},
 	}
 	for _, istc := range internetServiceTestCases {
@@ -533,18 +533,18 @@ func TestReconcileInternetServiceCreate(t *testing.T) {
 			if istc.expTagFound {
 				mockOscTagInterface.
 					EXPECT().
-					ReadTag(gomock.Eq("Name"), gomock.Eq(internetServiceName)).
+					ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(internetServiceName)).
 					Return(&tag, istc.expReadTagErr)
 			} else {
 				mockOscTagInterface.
 					EXPECT().
-					ReadTag(gomock.Eq("Name"), gomock.Eq(internetServiceName)).
+					ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(internetServiceName)).
 					Return(nil, istc.expReadTagErr)
 			}
 
 			mockOscInternetServiceInterface.
 				EXPECT().
-				CreateInternetService(gomock.Eq(internetServiceName)).
+				CreateInternetService(gomock.Any(), gomock.Eq(internetServiceName)).
 				Return(nil, istc.expCreateInternetServiceErr)
 
 			reconcileInternetService, err := reconcileInternetService(ctx, clusterScope, mockOscInternetServiceInterface, mockOscTagInterface)
@@ -582,7 +582,7 @@ func TestReconcileInternetServiceResourceId(t *testing.T) {
 			expTagFound:                    true,
 			expNetFound:                    true,
 			expReadTagErr:                  errors.New("ReadTag generic error"),
-			expReconcileInternetServiceErr: errors.New("ReadTag generic error Can not get tag for OscCluster test-system/test-osc"),
+			expReconcileInternetServiceErr: errors.New("cannot get tag: ReadTag generic error"),
 		},
 	}
 	for _, istc := range internetServiceTestCases {
@@ -603,12 +603,12 @@ func TestReconcileInternetServiceResourceId(t *testing.T) {
 				if istc.expTagFound {
 					mockOscTagInterface.
 						EXPECT().
-						ReadTag(gomock.Eq("Name"), gomock.Eq(internetServiceName)).
+						ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(internetServiceName)).
 						Return(&tag, istc.expReadTagErr)
 				} else {
 					mockOscTagInterface.
 						EXPECT().
-						ReadTag(gomock.Eq("Name"), gomock.Eq(internetServiceName)).
+						ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(internetServiceName)).
 						Return(nil, istc.expReadTagErr)
 				}
 			}
@@ -634,12 +634,12 @@ func TestReconcileDeleteInternetServiceGet(t *testing.T) {
 		expReconcileDeleteInternetServiceErr error
 	}{
 		{
-			name:                                 "failed to get interntservice",
+			name:                                 "failed to get internetservice",
 			spec:                                 defaultInternetServiceReconcile,
 			expNetFound:                          true,
 			expInternetServiceFound:              false,
 			expDescribeInternetServiceErr:        errors.New("GetInternetService generic error"),
-			expReconcileDeleteInternetServiceErr: errors.New("GetInternetService generic error"),
+			expReconcileDeleteInternetServiceErr: errors.New("get internetservice: GetInternetService generic error"),
 		},
 		{
 			name:                                 "remove finalizer (user delete internetService without cluster-api)",
@@ -677,12 +677,12 @@ func TestReconcileDeleteInternetServiceGet(t *testing.T) {
 			if istc.expInternetServiceFound {
 				mockOscInternetServiceInterface.
 					EXPECT().
-					GetInternetService(gomock.Eq(internetServiceId)).
+					GetInternetService(gomock.Any(), gomock.Eq(internetServiceId)).
 					Return(&readInternetService[0], istc.expDescribeInternetServiceErr)
 			} else {
 				mockOscInternetServiceInterface.
 					EXPECT().
-					GetInternetService(gomock.Eq(internetServiceId)).
+					GetInternetService(gomock.Any(), gomock.Eq(internetServiceId)).
 					Return(nil, istc.expDescribeInternetServiceErr)
 			}
 
@@ -711,7 +711,7 @@ func TestReconcileDeleteInternetServiceUnlink(t *testing.T) {
 			spec:                                 defaultInternetServiceReconcile,
 			expDescribeInternetServiceErr:        nil,
 			expUnlinkInternetServiceErr:          errors.New("UnlinkInternetService generic error"),
-			expReconcileDeleteInternetServiceErr: errors.New("UnlinkInternetService generic error Can not unlink internetService and net for Osccluster test-system/test-osc"),
+			expReconcileDeleteInternetServiceErr: errors.New("cannot unlink internetService and net: UnlinkInternetService generic error"),
 		},
 	}
 
@@ -738,12 +738,12 @@ func TestReconcileDeleteInternetServiceUnlink(t *testing.T) {
 			readInternetService := *readInternetServices.InternetServices
 			mockOscInternetServiceInterface.
 				EXPECT().
-				GetInternetService(gomock.Eq(internetServiceId)).
+				GetInternetService(gomock.Any(), gomock.Eq(internetServiceId)).
 				Return(&readInternetService[0], istc.expDescribeInternetServiceErr)
 
 			mockOscInternetServiceInterface.
 				EXPECT().
-				UnlinkInternetService(gomock.Eq(internetServiceId), gomock.Eq(netId)).
+				UnlinkInternetService(gomock.Any(), gomock.Eq(internetServiceId), gomock.Eq(netId)).
 				Return(istc.expUnlinkInternetServiceErr)
 
 			reconcileDeleteInternetService, err := reconcileDeleteInternetService(ctx, clusterScope, mockOscInternetServiceInterface)
@@ -787,7 +787,7 @@ func TestReconcileDeleteInternetServiceDelete(t *testing.T) {
 			expDeleteInternetServiceErr:          errors.New("DeleteInternetService generic error"),
 			expDescribeInternetServiceErr:        nil,
 			expUnlinkInternetServiceErr:          nil,
-			expReconcileDeleteInternetServiceErr: errors.New("DeleteInternetService generic error Can not delete internetService for Osccluster test-system/test-osc"),
+			expReconcileDeleteInternetServiceErr: errors.New("cannot delete internetService: DeleteInternetService generic error"),
 		},
 	}
 
@@ -812,23 +812,23 @@ func TestReconcileDeleteInternetServiceDelete(t *testing.T) {
 			if istc.expInternetServiceFound {
 				mockOscInternetServiceInterface.
 					EXPECT().
-					GetInternetService(gomock.Eq(internetServiceId)).
+					GetInternetService(gomock.Any(), gomock.Eq(internetServiceId)).
 					Return(&readInternetService[0], istc.expDescribeInternetServiceErr)
 			} else {
 				mockOscInternetServiceInterface.
 					EXPECT().
-					GetInternetService(gomock.Eq(internetServiceId)).
+					GetInternetService(gomock.Any(), gomock.Eq(internetServiceId)).
 					Return(nil, istc.expDescribeInternetServiceErr)
 			}
 
 			mockOscInternetServiceInterface.
 				EXPECT().
-				UnlinkInternetService(gomock.Eq(internetServiceId), gomock.Eq(netId)).
+				UnlinkInternetService(gomock.Any(), gomock.Eq(internetServiceId), gomock.Eq(netId)).
 				Return(istc.expUnlinkInternetServiceErr)
 
 			mockOscInternetServiceInterface.
 				EXPECT().
-				DeleteInternetService(gomock.Eq(internetServiceId)).
+				DeleteInternetService(gomock.Any(), gomock.Eq(internetServiceId)).
 				Return(istc.expDeleteInternetServiceErr)
 
 			netRef := clusterScope.GetNetRef()
@@ -859,12 +859,12 @@ func TestReconcileDeleteInternetServiceResourceId(t *testing.T) {
 			spec: infrastructurev1beta1.OscClusterSpec{
 				Network: infrastructurev1beta1.OscNetwork{},
 			},
-			expReconcileDeleteInternetServiceErr: errors.New("cluster-api-net-uid does not exist"),
+			expReconcileDeleteInternetServiceErr: errors.New("get net: cluster-api-net-uid does not exist"),
 		},
 		{
 			name:                                 "net does not exist",
 			spec:                                 defaultInternetServiceInitialize,
-			expReconcileDeleteInternetServiceErr: errors.New("test-net-uid does not exist"),
+			expReconcileDeleteInternetServiceErr: errors.New("get net: test-net-uid does not exist"),
 		},
 	}
 

--- a/controllers/osccluster_loadbalancer_controller_unit_test.go
+++ b/controllers/osccluster_loadbalancer_controller_unit_test.go
@@ -541,7 +541,7 @@ func TestReconcileLoadBalancer(t *testing.T) {
 			expCreateLoadBalancerErr:      nil,
 			expConfigureLoadBalancerErr:   nil,
 			expCreateLoadbalancerTagErr:   errors.New("CreateLoadbalancerTag generic error"),
-			expReconcileLoadBalancerErr:   errors.New("CreateLoadbalancerTag generic error Can not tag loadBalancer for OscCluster test-system/test-osc"),
+			expReconcileLoadBalancerErr:   errors.New("cannot tag loadBalancer: CreateLoadbalancerTag generic error"),
 		},
 		{
 			name:                          "failed to delete outbound Sg for loadBalancer",
@@ -558,7 +558,7 @@ func TestReconcileLoadBalancer(t *testing.T) {
 			expCreateLoadBalancerErr:      nil,
 			expConfigureLoadBalancerErr:   nil,
 			expCreateLoadbalancerTagErr:   nil,
-			expReconcileLoadBalancerErr:   errors.New("DeleteSecurityGroupsRules generic error can not empty Outbound sg rules for loadBalancer for Osccluster test-system/test-osc"),
+			expReconcileLoadBalancerErr:   errors.New("cannot delete default sg rules for loadBalancer: DeleteSecurityGroupsRules generic error"),
 		},
 		{
 			name:                          "failed to configure loadBalancer",
@@ -575,7 +575,7 @@ func TestReconcileLoadBalancer(t *testing.T) {
 			expCreateLoadBalancerErr:      nil,
 			expCreateLoadbalancerTagErr:   nil,
 			expConfigureLoadBalancerErr:   errors.New("ConfigureLoadBalancer generic error"),
-			expReconcileLoadBalancerErr:   errors.New("ConfigureLoadBalancer generic error Can not configure healthcheck for Osccluster test-system/test-osc"),
+			expReconcileLoadBalancerErr:   errors.New("cannot configure healthcheck: ConfigureLoadBalancer generic error"),
 		},
 	}
 	for _, lbtc := range loadBalancerTestCases {
@@ -617,23 +617,23 @@ func TestReconcileLoadBalancer(t *testing.T) {
 			if lbtc.expLoadBalancerFound {
 				mockOscLoadBalancerInterface.
 					EXPECT().
-					GetLoadBalancer(gomock.Eq(&loadBalancerSpec)).
+					GetLoadBalancer(gomock.Any(), gomock.Eq(&loadBalancerSpec)).
 					Return(&readLoadBalancer[0], lbtc.expDescribeLoadBalancerErr)
 			} else {
 				mockOscLoadBalancerInterface.
 					EXPECT().
-					GetLoadBalancer(gomock.Eq(&loadBalancerSpec)).
+					GetLoadBalancer(gomock.Any(), gomock.Eq(&loadBalancerSpec)).
 					Return(nil, lbtc.expDescribeLoadBalancerErr)
 			}
 			if lbtc.expCreateLoadBalancerFound {
 				mockOscLoadBalancerInterface.
 					EXPECT().
-					CreateLoadBalancer(gomock.Eq(&loadBalancerSpec), gomock.Eq(subnetId), gomock.Eq(securityGroupId)).
+					CreateLoadBalancer(gomock.Any(), gomock.Eq(&loadBalancerSpec), gomock.Eq(subnetId), gomock.Eq(securityGroupId)).
 					Return(loadBalancer.LoadBalancer, lbtc.expCreateLoadBalancerErr)
 			} else {
 				mockOscLoadBalancerInterface.
 					EXPECT().
-					CreateLoadBalancer(gomock.Eq(&loadBalancerSpec), gomock.Eq(subnetId), gomock.Eq(securityGroupId)).
+					CreateLoadBalancer(gomock.Any(), gomock.Eq(&loadBalancerSpec), gomock.Eq(subnetId), gomock.Eq(securityGroupId)).
 					Return(nil, lbtc.expCreateLoadBalancerErr)
 			}
 
@@ -641,23 +641,23 @@ func TestReconcileLoadBalancer(t *testing.T) {
 				if lbtc.expDeleteOutboundSgRuleErr == nil {
 					mockOscSecurityGroupInterface.
 						EXPECT().
-						DeleteSecurityGroupRule(gomock.Eq(securityGroupId), gomock.Eq("Outbound"), gomock.Eq("-1"), gomock.Eq("0.0.0.0/0"), gomock.Eq(""), gomock.Eq(int32(0)), gomock.Eq(int32(0))).
+						DeleteSecurityGroupRule(gomock.Any(), gomock.Eq(securityGroupId), gomock.Eq("Outbound"), gomock.Eq("-1"), gomock.Eq("0.0.0.0/0"), gomock.Eq(""), gomock.Eq(int32(0)), gomock.Eq(int32(0))).
 						Return(lbtc.expDeleteOutboundSgRuleErr)
 					if lbtc.expConfigureLoadBalancerFound {
 						mockOscLoadBalancerInterface.
 							EXPECT().
-							ConfigureHealthCheck(gomock.Eq(&loadBalancerSpec)).
+							ConfigureHealthCheck(gomock.Any(), gomock.Eq(&loadBalancerSpec)).
 							Return(loadBalancer.LoadBalancer, lbtc.expConfigureLoadBalancerErr)
 					} else {
 						mockOscLoadBalancerInterface.
 							EXPECT().
-							ConfigureHealthCheck(gomock.Eq(&loadBalancerSpec)).
+							ConfigureHealthCheck(gomock.Any(), gomock.Eq(&loadBalancerSpec)).
 							Return(nil, lbtc.expConfigureLoadBalancerErr)
 					}
 				} else {
 					mockOscSecurityGroupInterface.
 						EXPECT().
-						DeleteSecurityGroupRule(gomock.Eq(securityGroupId), gomock.Eq("Outbound"), gomock.Eq("-1"), gomock.Eq("0.0.0.0/0"), gomock.Eq(""), gomock.Eq(int32(0)), gomock.Eq(int32(0))).
+						DeleteSecurityGroupRule(gomock.Any(), gomock.Eq(securityGroupId), gomock.Eq("Outbound"), gomock.Eq("-1"), gomock.Eq("0.0.0.0/0"), gomock.Eq(""), gomock.Eq(int32(0)), gomock.Eq(int32(0))).
 						Return(lbtc.expDeleteOutboundSgRuleErr)
 				}
 				if lbtc.expCreateLoadBalancerTag {
@@ -669,7 +669,7 @@ func TestReconcileLoadBalancer(t *testing.T) {
 
 					mockOscLoadBalancerInterface.
 						EXPECT().
-						CreateLoadBalancerTag(gomock.Eq(&loadBalancerSpec), gomock.Eq(nameTag)).
+						CreateLoadBalancerTag(gomock.Any(), gomock.Eq(&loadBalancerSpec), gomock.Eq(nameTag)).
 						Return(lbtc.expCreateLoadbalancerTagErr)
 				}
 			}
@@ -733,7 +733,7 @@ func TestReconcileLoadBalancerGet(t *testing.T) {
 			expCreateLoadBalancerErr:      nil,
 			expConfigureLoadBalancerErr:   nil,
 			expGetLoadBalancerTagErr:      nil,
-			expReconcileLoadBalancerErr:   errors.New("GetLoadBalancer generic error"),
+			expReconcileLoadBalancerErr:   errors.New("cannot get loadbalancer: GetLoadBalancer generic error"),
 		},
 	}
 
@@ -789,18 +789,18 @@ func TestReconcileLoadBalancerGet(t *testing.T) {
 			if lbtc.expLoadBalancerFound {
 				mockOscLoadBalancerInterface.
 					EXPECT().
-					GetLoadBalancer(gomock.Eq(&loadBalancerSpec)).
+					GetLoadBalancer(gomock.Any(), gomock.Eq(&loadBalancerSpec)).
 					Return(&readLoadBalancer[0], lbtc.expDescribeLoadBalancerErr)
 				if lbtc.expGetLoadBalancerTagFound {
 					mockOscLoadBalancerInterface.
 						EXPECT().
-						GetLoadBalancerTag(gomock.Eq(&loadBalancerSpec)).
+						GetLoadBalancerTag(gomock.Any(), gomock.Eq(&loadBalancerSpec)).
 						Return(&readLoadBalancerTag[0], lbtc.expGetLoadBalancerTagErr)
 				}
 			} else {
 				mockOscLoadBalancerInterface.
 					EXPECT().
-					GetLoadBalancer(gomock.Eq(&loadBalancerSpec)).
+					GetLoadBalancer(gomock.Any(), gomock.Eq(&loadBalancerSpec)).
 					Return(nil, lbtc.expDescribeLoadBalancerErr)
 			}
 			reconcileLoadBalancer, err := reconcileLoadBalancer(ctx, clusterScope, mockOscLoadBalancerInterface, mockOscSecurityGroupInterface)
@@ -850,7 +850,7 @@ func TestReconcileLoadBalancerGetTag(t *testing.T) {
 			expConfigureLoadBalancerErr:   nil,
 			expGetLoadBalancerTagErr:      errors.New("GetLoadBalancerTag generic error"),
 			expCreateLoadBalancerTagErr:   nil,
-			expReconcileLoadBalancerErr:   errors.New("GetLoadBalancerTag generic error"),
+			expReconcileLoadBalancerErr:   errors.New("get loadbalancer tag: GetLoadBalancerTag generic error"),
 		},
 		{
 			name:                          "a loadBalancer with the same name already exists without tag",
@@ -868,7 +868,7 @@ func TestReconcileLoadBalancerGetTag(t *testing.T) {
 			expConfigureLoadBalancerErr:   nil,
 			expGetLoadBalancerTagErr:      nil,
 			expCreateLoadBalancerTagErr:   nil,
-			expReconcileLoadBalancerErr:   errors.New("A LoadBalancer test-loadbalancer already exists"),
+			expReconcileLoadBalancerErr:   errors.New("A LoadBalancer with name test-loadbalancer already exists"),
 		},
 		{
 			name:                          "a loadBalancer with the same name in other cluster already exists",
@@ -947,23 +947,23 @@ func TestReconcileLoadBalancerGetTag(t *testing.T) {
 			if lbtc.expLoadBalancerFound {
 				mockOscLoadBalancerInterface.
 					EXPECT().
-					GetLoadBalancer(gomock.Eq(&loadBalancerSpec)).
+					GetLoadBalancer(gomock.Any(), gomock.Eq(&loadBalancerSpec)).
 					Return(&readLoadBalancer[0], lbtc.expDescribeLoadBalancerErr)
 				if lbtc.expGetLoadBalancerTagFound {
 					mockOscLoadBalancerInterface.
 						EXPECT().
-						GetLoadBalancerTag(gomock.Eq(&loadBalancerSpec)).
+						GetLoadBalancerTag(gomock.Any(), gomock.Eq(&loadBalancerSpec)).
 						Return(&readLoadBalancerTag[0], lbtc.expGetLoadBalancerTagErr)
 				} else {
 					mockOscLoadBalancerInterface.
 						EXPECT().
-						GetLoadBalancerTag(gomock.Eq(&loadBalancerSpec)).
+						GetLoadBalancerTag(gomock.Any(), gomock.Eq(&loadBalancerSpec)).
 						Return(nil, lbtc.expGetLoadBalancerTagErr)
 				}
 			} else {
 				mockOscLoadBalancerInterface.
 					EXPECT().
-					GetLoadBalancer(gomock.Eq(&loadBalancerSpec)).
+					GetLoadBalancer(gomock.Any(), gomock.Eq(&loadBalancerSpec)).
 					Return(nil, lbtc.expDescribeLoadBalancerErr)
 			}
 			reconcileLoadBalancer, err := reconcileLoadBalancer(ctx, clusterScope, mockOscLoadBalancerInterface, mockOscSecurityGroupInterface)
@@ -994,7 +994,7 @@ func TestReconcileLoadBalancerCreate(t *testing.T) {
 			expCreateLoadBalancerErr:    errors.New("CreateLoadBalancer generic error"),
 			expConfigureLoadBalancerErr: nil,
 			expDescribeLoadBalancerErr:  nil,
-			expReconcileLoadBalancerErr: errors.New("CreateLoadBalancer generic error Can not create loadBalancer for Osccluster test-system/test-osc"),
+			expReconcileLoadBalancerErr: errors.New("cannot create loadBalancer: CreateLoadBalancer generic error"),
 		},
 	}
 	for _, lbtc := range loadBalancerTestCases {
@@ -1016,11 +1016,11 @@ func TestReconcileLoadBalancerCreate(t *testing.T) {
 			loadBalancerSpec := lbtc.spec.Network.LoadBalancer
 			mockOscLoadBalancerInterface.
 				EXPECT().
-				GetLoadBalancer(gomock.Eq(&loadBalancerSpec)).
+				GetLoadBalancer(gomock.Any(), gomock.Eq(&loadBalancerSpec)).
 				Return(nil, lbtc.expDescribeLoadBalancerErr)
 			mockOscLoadBalancerInterface.
 				EXPECT().
-				CreateLoadBalancer(gomock.Eq(&loadBalancerSpec), gomock.Eq(subnetId), gomock.Eq(securityGroupId)).
+				CreateLoadBalancer(gomock.Any(), gomock.Eq(&loadBalancerSpec), gomock.Eq(subnetId), gomock.Eq(securityGroupId)).
 				Return(nil, lbtc.expCreateLoadBalancerErr)
 			reconcileLoadBalancer, err := reconcileLoadBalancer(ctx, clusterScope, mockOscLoadBalancerInterface, mockOscSecurityGroupInterface)
 			if lbtc.expReconcileLoadBalancerErr != nil {
@@ -1049,7 +1049,7 @@ func TestReconcileLoadBalancerResourceId(t *testing.T) {
 			expSubnetFound:              false,
 			expSecurityGroupFound:       false,
 			expDescribeLoadBalancerErr:  nil,
-			expReconcileLoadBalancerErr: errors.New("test-subnet-uid does not exist"),
+			expReconcileLoadBalancerErr: errors.New("cannot get subnet: test-subnet-uid does not exist"),
 		},
 		{
 			name:                        "securitygroup does not exist",
@@ -1057,7 +1057,7 @@ func TestReconcileLoadBalancerResourceId(t *testing.T) {
 			expSubnetFound:              true,
 			expSecurityGroupFound:       false,
 			expDescribeLoadBalancerErr:  nil,
-			expReconcileLoadBalancerErr: errors.New("test-securitygroup-uid does not exist"),
+			expReconcileLoadBalancerErr: errors.New("cannot get security group: test-securitygroup-uid does not exist"),
 		},
 	}
 	for _, lbtc := range loadBalancerTestCases {
@@ -1084,7 +1084,7 @@ func TestReconcileLoadBalancerResourceId(t *testing.T) {
 			loadBalancerSpec := lbtc.spec.Network.LoadBalancer
 			mockOscLoadBalancerInterface.
 				EXPECT().
-				GetLoadBalancer(gomock.Eq(&loadBalancerSpec)).
+				GetLoadBalancer(gomock.Any(), gomock.Eq(&loadBalancerSpec)).
 				Return(nil, lbtc.expDescribeLoadBalancerErr)
 			reconcileLoadBalancer, err := reconcileLoadBalancer(ctx, clusterScope, mockOscLoadBalancerInterface, mockOscSecurityGroupInterface)
 			if lbtc.expReconcileLoadBalancerErr != nil {
@@ -1136,7 +1136,7 @@ func TestReconcileDeleteLoadBalancerDelete(t *testing.T) {
 			expCheckLoadBalancerDeregisterVmErr: nil,
 			expGetLoadBalancerTagErr:            nil,
 			expDeleteLoadBalancerTagErr:         nil,
-			expReconcileDeleteLoadBalancerErr:   errors.New("DeleteLoadBalancer generic error Can not delete loadBalancer for Osccluster test-system/test-osc"),
+			expReconcileDeleteLoadBalancerErr:   errors.New("cannot delete loadBalancer: DeleteLoadBalancer generic error"),
 		},
 	}
 	for _, lbtc := range loadBalancerTestCases {
@@ -1176,7 +1176,7 @@ func TestReconcileDeleteLoadBalancerDelete(t *testing.T) {
 			if lbtc.expGetLoadBalancerTagFound {
 				mockOscLoadBalancerInterface.
 					EXPECT().
-					GetLoadBalancerTag(gomock.Eq(&loadBalancerSpec)).
+					GetLoadBalancerTag(gomock.Any(), gomock.Eq(&loadBalancerSpec)).
 					Return(&readLoadBalancerTag[0], lbtc.expGetLoadBalancerTagErr)
 			}
 			if lbtc.expDeleteLoadBalancerTagFound {
@@ -1185,21 +1185,21 @@ func TestReconcileDeleteLoadBalancerDelete(t *testing.T) {
 				}
 				mockOscLoadBalancerInterface.
 					EXPECT().
-					DeleteLoadBalancerTag(gomock.Eq(&loadBalancerSpec), gomock.Eq(loadBalancerTagKey)).
+					DeleteLoadBalancerTag(gomock.Any(), gomock.Eq(&loadBalancerSpec), gomock.Eq(loadBalancerTagKey)).
 					Return(lbtc.expDeleteLoadBalancerTagErr)
 			}
 			mockOscLoadBalancerInterface.
 				EXPECT().
-				GetLoadBalancer(gomock.Eq(&loadBalancerSpec)).
+				GetLoadBalancer(gomock.Any(), gomock.Eq(&loadBalancerSpec)).
 				Return(&readLoadBalancer[0], lbtc.expDescribeLoadBalancerErr)
 			mockOscLoadBalancerInterface.
 				EXPECT().
-				DeleteLoadBalancer(gomock.Eq(&loadBalancerSpec)).
+				DeleteLoadBalancer(gomock.Any(), gomock.Eq(&loadBalancerSpec)).
 				Return(lbtc.expDeleteLoadBalancerErr)
 
 			mockOscLoadBalancerInterface.
 				EXPECT().
-				CheckLoadBalancerDeregisterVm(gomock.Eq(clockInsideLoop), gomock.Eq(clockLoop), gomock.Eq(&loadBalancerSpec)).
+				CheckLoadBalancerDeregisterVm(gomock.Any(), gomock.Eq(clockInsideLoop), gomock.Eq(clockLoop), gomock.Eq(&loadBalancerSpec)).
 				Return(lbtc.expCheckLoadBalancerDeregisterVmErr)
 
 			reconcileDeleteLoadBalancer, err := reconcileDeleteLoadBalancer(ctx, clusterScope, mockOscLoadBalancerInterface)
@@ -1274,7 +1274,7 @@ func TestReconcileDeleteLoadBalancerDeleteTag(t *testing.T) {
 			expCheckLoadBalancerDeregisterVmErr:   nil,
 			expGetLoadBalancerTagErr:              nil,
 			expDeleteLoadBalancerTagErr:           errors.New("DeleteLoadBalancerTag generic error"),
-			expReconcileDeleteLoadBalancerErr:     errors.New("DeleteLoadBalancerTag generic error Can not delete loadBalancer Tag for OscCluster test-system/test-osc"),
+			expReconcileDeleteLoadBalancerErr:     errors.New("cannot delete loadBalancer tag: DeleteLoadBalancerTag generic error"),
 		},
 	}
 	for _, lbtc := range loadBalancerTestCases {
@@ -1319,12 +1319,12 @@ func TestReconcileDeleteLoadBalancerDeleteTag(t *testing.T) {
 			if lbtc.expGetLoadBalancerTagFound {
 				mockOscLoadBalancerInterface.
 					EXPECT().
-					GetLoadBalancerTag(gomock.Eq(&loadBalancerSpec)).
+					GetLoadBalancerTag(gomock.Any(), gomock.Eq(&loadBalancerSpec)).
 					Return(&readLoadBalancerTag[0], lbtc.expGetLoadBalancerTagErr)
 			} else {
 				mockOscLoadBalancerInterface.
 					EXPECT().
-					GetLoadBalancerTag(gomock.Eq(&loadBalancerSpec)).
+					GetLoadBalancerTag(gomock.Any(), gomock.Eq(&loadBalancerSpec)).
 					Return(nil, lbtc.expGetLoadBalancerTagErr)
 			}
 			if lbtc.expDeleteLoadBalancerTagFound {
@@ -1333,17 +1333,17 @@ func TestReconcileDeleteLoadBalancerDeleteTag(t *testing.T) {
 				}
 				mockOscLoadBalancerInterface.
 					EXPECT().
-					DeleteLoadBalancerTag(gomock.Eq(&loadBalancerSpec), gomock.Eq(loadBalancerTagKey)).
+					DeleteLoadBalancerTag(gomock.Any(), gomock.Eq(&loadBalancerSpec), gomock.Eq(loadBalancerTagKey)).
 					Return(lbtc.expDeleteLoadBalancerTagErr)
 			}
 			mockOscLoadBalancerInterface.
 				EXPECT().
-				GetLoadBalancer(gomock.Eq(&loadBalancerSpec)).
+				GetLoadBalancer(gomock.Any(), gomock.Eq(&loadBalancerSpec)).
 				Return(&readLoadBalancer[0], lbtc.expDescribeLoadBalancerErr)
 			if lbtc.expCheckLoadBalancerDeregisterVmFound {
 				mockOscLoadBalancerInterface.
 					EXPECT().
-					CheckLoadBalancerDeregisterVm(gomock.Eq(clockInsideLoop), gomock.Eq(clockLoop), gomock.Eq(&loadBalancerSpec)).
+					CheckLoadBalancerDeregisterVm(gomock.Any(), gomock.Eq(clockInsideLoop), gomock.Eq(clockLoop), gomock.Eq(&loadBalancerSpec)).
 					Return(lbtc.expCheckLoadBalancerDeregisterVmErr)
 			}
 			reconcileDeleteLoadBalancer, err := reconcileDeleteLoadBalancer(ctx, clusterScope, mockOscLoadBalancerInterface)
@@ -1431,12 +1431,12 @@ func TestReconcileDeleteLoadBalancerDeleteWithoutSpec(t *testing.T) {
 			if lbtc.expGetLoadBalancerTagFound {
 				mockOscLoadBalancerInterface.
 					EXPECT().
-					GetLoadBalancerTag(gomock.Eq(loadBalancerSpec)).
+					GetLoadBalancerTag(gomock.Any(), gomock.Eq(loadBalancerSpec)).
 					Return(&readLoadBalancerTag[0], lbtc.expGetLoadBalancerTagErr)
 			} else {
 				mockOscLoadBalancerInterface.
 					EXPECT().
-					GetLoadBalancerTag(gomock.Eq(loadBalancerSpec)).
+					GetLoadBalancerTag(gomock.Any(), gomock.Eq(loadBalancerSpec)).
 					Return(nil, lbtc.expGetLoadBalancerTagErr)
 			}
 			if lbtc.expDeleteLoadBalancerTagFound {
@@ -1445,22 +1445,22 @@ func TestReconcileDeleteLoadBalancerDeleteWithoutSpec(t *testing.T) {
 				}
 				mockOscLoadBalancerInterface.
 					EXPECT().
-					DeleteLoadBalancerTag(gomock.Eq(loadBalancerSpec), gomock.Eq(loadBalancerTagKey)).
+					DeleteLoadBalancerTag(gomock.Any(), gomock.Eq(loadBalancerSpec), gomock.Eq(loadBalancerTagKey)).
 					Return(lbtc.expDeleteLoadBalancerTagErr)
 			}
 			mockOscLoadBalancerInterface.
 				EXPECT().
-				GetLoadBalancer(gomock.Eq(loadBalancerSpec)).
+				GetLoadBalancer(gomock.Any(), gomock.Eq(loadBalancerSpec)).
 				Return(&readLoadBalancer[0], lbtc.expDescribeLoadBalancerErr)
 			if lbtc.expCheckLoadBalancerDeregisterVmFound {
 				mockOscLoadBalancerInterface.
 					EXPECT().
-					CheckLoadBalancerDeregisterVm(gomock.Eq(clockInsideLoop), gomock.Eq(clockLoop), gomock.Eq(loadBalancerSpec)).
+					CheckLoadBalancerDeregisterVm(gomock.Any(), gomock.Eq(clockInsideLoop), gomock.Eq(clockLoop), gomock.Eq(loadBalancerSpec)).
 					Return(lbtc.expCheckLoadBalancerDeregisterVmErr)
 			}
 			mockOscLoadBalancerInterface.
 				EXPECT().
-				DeleteLoadBalancer(gomock.Eq(loadBalancerSpec)).
+				DeleteLoadBalancer(gomock.Any(), gomock.Eq(loadBalancerSpec)).
 				Return(lbtc.expDeleteLoadBalancerErr)
 			reconcileDeleteLoadBalancer, err := reconcileDeleteLoadBalancer(ctx, clusterScope, mockOscLoadBalancerInterface)
 			if lbtc.expReconcileDeleteLoadBalancerErr != nil {
@@ -1495,7 +1495,7 @@ func TestReconcileDeleteLoadBalancerCheck(t *testing.T) {
 			expDescribeLoadBalancerErr:            nil,
 			expGetLoadBalancerTagErr:              nil,
 			expCheckLoadBalancerDeregisterVmErr:   errors.New("CheckLoadBalancerDeregisterVm generic error"),
-			expReconcileDeleteLoadBalancerErr:     errors.New("CheckLoadBalancerDeregisterVm generic error VmBackend is not deregister in loadBalancer test-loadbalancer for OscCluster test-system/test-osc"),
+			expReconcileDeleteLoadBalancerErr:     errors.New("VmBackend is stll registered in loadBalancer: CheckLoadBalancerDeregisterVm generic error"),
 		},
 	}
 	for _, lbtc := range loadBalancerTestCases {
@@ -1535,18 +1535,18 @@ func TestReconcileDeleteLoadBalancerCheck(t *testing.T) {
 			if lbtc.expGetLoadBalancerTagFound {
 				mockOscLoadBalancerInterface.
 					EXPECT().
-					GetLoadBalancerTag(gomock.Eq(&loadBalancerSpec)).
+					GetLoadBalancerTag(gomock.Any(), gomock.Eq(&loadBalancerSpec)).
 					Return(&readLoadBalancerTag[0], lbtc.expGetLoadBalancerTagErr)
 			}
 			mockOscLoadBalancerInterface.
 				EXPECT().
-				GetLoadBalancer(gomock.Eq(&loadBalancerSpec)).
+				GetLoadBalancer(gomock.Any(), gomock.Eq(&loadBalancerSpec)).
 				Return(&readLoadBalancer[0], lbtc.expDescribeLoadBalancerErr)
 
 			if lbtc.expCheckLoadBalancerDeregisterVmFound {
 				mockOscLoadBalancerInterface.
 					EXPECT().
-					CheckLoadBalancerDeregisterVm(gomock.Eq(clockInsideLoop), gomock.Eq(clockLoop), gomock.Eq(&loadBalancerSpec)).
+					CheckLoadBalancerDeregisterVm(gomock.Any(), gomock.Eq(clockInsideLoop), gomock.Eq(clockLoop), gomock.Eq(&loadBalancerSpec)).
 					Return(lbtc.expCheckLoadBalancerDeregisterVmErr)
 			}
 
@@ -1592,7 +1592,7 @@ func TestReconcileDeleteLoadBalancerGet(t *testing.T) {
 			loadBalancerSpec.SetDefaultValue()
 			mockOscLoadBalancerInterface.
 				EXPECT().
-				GetLoadBalancer(gomock.Eq(&loadBalancerSpec)).
+				GetLoadBalancer(gomock.Any(), gomock.Eq(&loadBalancerSpec)).
 				Return(nil, lbtc.expDescribeLoadBalancerErr)
 			reconcileDeleteLoadBalancer, err := reconcileDeleteLoadBalancer(ctx, clusterScope, mockOscLoadBalancerInterface)
 			if lbtc.expReconcileDeleteLoadBalancerErr != nil {

--- a/controllers/osccluster_natservice_controller_unit_test.go
+++ b/controllers/osccluster_natservice_controller_unit_test.go
@@ -360,7 +360,7 @@ func TestReconcileNatServiceCreate(t *testing.T) {
 			expGetNatServiceErr:       nil,
 			expCreateNatServiceFound:  false,
 			expCreateNatServiceErr:    errors.New("CreateNatService generic error"),
-			expReconcileNatServiceErr: errors.New("CreateNatService generic error Can not create natService for Osccluster test-system/test-osc"),
+			expReconcileNatServiceErr: errors.New("cannot create natService: CreateNatService generic error"),
 		},
 	}
 	for _, nstc := range natServiceTestCases {
@@ -378,12 +378,12 @@ func TestReconcileNatServiceCreate(t *testing.T) {
 			if nstc.expTagFound {
 				mockOscTagInterface.
 					EXPECT().
-					ReadTag(gomock.Eq("Name"), gomock.Eq(natServiceName)).
+					ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(natServiceName)).
 					Return(&tag, nstc.expReadTagErr)
 			} else {
 				mockOscTagInterface.
 					EXPECT().
-					ReadTag(gomock.Eq("Name"), gomock.Eq(natServiceName)).
+					ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(natServiceName)).
 					Return(nil, nstc.expReadTagErr)
 			}
 			publicIpName := nstc.spec.Network.NatService.PublicIpName + "-uid"
@@ -411,12 +411,12 @@ func TestReconcileNatServiceCreate(t *testing.T) {
 			if nstc.expCreateNatServiceFound {
 				mockOscNatServiceInterface.
 					EXPECT().
-					CreateNatService(gomock.Eq(publicIpId), gomock.Eq(subnetId), gomock.Eq(natServiceName), gomock.Eq(clusterName)).
+					CreateNatService(gomock.Any(), gomock.Eq(publicIpId), gomock.Eq(subnetId), gomock.Eq(natServiceName), gomock.Eq(clusterName)).
 					Return(natService.NatService, nstc.expCreateNatServiceErr)
 			} else {
 				mockOscNatServiceInterface.
 					EXPECT().
-					CreateNatService(gomock.Eq(publicIpId), gomock.Eq(subnetId), gomock.Eq(natServiceName), gomock.Eq(clusterName)).
+					CreateNatService(gomock.Any(), gomock.Eq(publicIpId), gomock.Eq(subnetId), gomock.Eq(natServiceName), gomock.Eq(clusterName)).
 					Return(nil, nstc.expCreateNatServiceErr)
 			}
 			reconcileNatService, err := reconcileNatService(ctx, clusterScope, mockOscNatServiceInterface, mockOscTagInterface)
@@ -483,12 +483,12 @@ func TestReconcileNatServiceGet(t *testing.T) {
 			if nstc.expTagFound {
 				mockOscTagInterface.
 					EXPECT().
-					ReadTag(gomock.Eq("Name"), gomock.Eq(natServiceName)).
+					ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(natServiceName)).
 					Return(&tag, nstc.expReadTagErr)
 			} else {
 				mockOscTagInterface.
 					EXPECT().
-					ReadTag(gomock.Eq("Name"), gomock.Eq(natServiceName)).
+					ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(natServiceName)).
 					Return(nil, nstc.expReadTagErr)
 			}
 			publicIpName := nstc.spec.Network.NatService.PublicIpName + "-uid"
@@ -522,12 +522,12 @@ func TestReconcileNatServiceGet(t *testing.T) {
 			if nstc.expNatServiceFound {
 				mockOscNatServiceInterface.
 					EXPECT().
-					GetNatService(gomock.Eq(natServiceId)).
+					GetNatService(gomock.Any(), gomock.Eq(natServiceId)).
 					Return(&readNatService[0], nstc.expGetNatServiceErr)
 			} else {
 				mockOscNatServiceInterface.
 					EXPECT().
-					GetNatService(gomock.Eq(natServiceId)).
+					GetNatService(gomock.Any(), gomock.Eq(natServiceId)).
 					Return(nil, nstc.expGetNatServiceErr)
 			}
 			reconcileNatService, err := reconcileNatService(ctx, clusterScope, mockOscNatServiceInterface, mockOscTagInterface)
@@ -577,7 +577,7 @@ func TestReconcileNatServiceResourceId(t *testing.T) {
 			expSubnetFound:            true,
 			expTagFound:               false,
 			expReadTagErr:             errors.New("ReadTag generic error"),
-			expReconcileNatServiceErr: errors.New("ReadTag generic error Can not get tag for OscCluster test-system/test-osc"),
+			expReconcileNatServiceErr: errors.New("cannot get tag: ReadTag generic error"),
 		},
 	}
 	for _, nstc := range natServiceTestCases {
@@ -608,12 +608,12 @@ func TestReconcileNatServiceResourceId(t *testing.T) {
 				if nstc.expTagFound {
 					mockOscTagInterface.
 						EXPECT().
-						ReadTag(gomock.Eq("Name"), gomock.Eq(natServiceName)).
+						ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(natServiceName)).
 						Return(&tag, nstc.expReadTagErr)
 				} else {
 					mockOscTagInterface.
 						EXPECT().
-						ReadTag(gomock.Eq("Name"), gomock.Eq(natServiceName)).
+						ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(natServiceName)).
 						Return(nil, nstc.expReadTagErr)
 				}
 			}
@@ -682,12 +682,12 @@ func TestReconcileDeleteNatServiceDeleteWithoutSpec(t *testing.T) {
 
 			mockOscNatServiceInterface.
 				EXPECT().
-				GetNatService(gomock.Eq(natServiceId)).
+				GetNatService(gomock.Any(), gomock.Eq(natServiceId)).
 				Return(&readNatService[0], nstc.expGetNatServiceErr)
 
 			mockOscNatServiceInterface.
 				EXPECT().
-				DeleteNatService(gomock.Eq(natServiceId)).
+				DeleteNatService(gomock.Any(), gomock.Eq(natServiceId)).
 				Return(nstc.expDeleteNatServiceErr)
 
 			reconcileDeleteNatService, err := reconcileDeleteNatService(ctx, clusterScope, mockOscNatServiceInterface)
@@ -731,7 +731,7 @@ func TestReconcileDeleteNatServiceDelete(t *testing.T) {
 			expNatServiceFound:              true,
 			expGetNatServiceErr:             nil,
 			expDeleteNatServiceErr:          errors.New("DeleteNatService generic error"),
-			expReconcileDeleteNatServiceErr: errors.New("DeleteNatService generic error Can not delete natService for Osccluster test-system/test-osc"),
+			expReconcileDeleteNatServiceErr: errors.New("cannot delete natService: DeleteNatService generic error"),
 		},
 	}
 	for _, nstc := range natServiceTestCases {
@@ -760,17 +760,17 @@ func TestReconcileDeleteNatServiceDelete(t *testing.T) {
 			if nstc.expNatServiceFound {
 				mockOscNatServiceInterface.
 					EXPECT().
-					GetNatService(gomock.Eq(natServiceId)).
+					GetNatService(gomock.Any(), gomock.Eq(natServiceId)).
 					Return(&readNatService[0], nstc.expGetNatServiceErr)
 			} else {
 				mockOscNatServiceInterface.
 					EXPECT().
-					GetNatService(gomock.Eq(natServiceId)).
+					GetNatService(gomock.Any(), gomock.Eq(natServiceId)).
 					Return(nil, nstc.expGetNatServiceErr)
 			}
 			mockOscNatServiceInterface.
 				EXPECT().
-				DeleteNatService(gomock.Eq(natServiceId)).
+				DeleteNatService(gomock.Any(), gomock.Eq(natServiceId)).
 				Return(nstc.expDeleteNatServiceErr)
 			reconcileDeleteNatService, err := reconcileDeleteNatService(ctx, clusterScope, mockOscNatServiceInterface)
 			if nstc.expReconcileDeleteNatServiceErr != nil {

--- a/controllers/osccluster_publicip_controller_unit_test.go
+++ b/controllers/osccluster_publicip_controller_unit_test.go
@@ -309,7 +309,7 @@ func TestCheckPublicIpOscAssociateResourceName(t *testing.T) {
 					},
 				},
 			},
-			expCheckPublicIpOscAssociateResourceNameErr: errors.New("publicIp test-publicip-test-uid does not exist in natService "),
+			expCheckPublicIpOscAssociateResourceNameErr: errors.New("publicIp test-publicip-test-uid does not exist in natService"),
 		},
 	}
 	for _, pitc := range publicIpTestCases {
@@ -421,7 +421,7 @@ func TestReconcilePublicIpGet(t *testing.T) {
 			expTagFound:             false,
 			expValidatePublicIpsErr: nil,
 			expReadTagErr:           errors.New("ReadTag generic error"),
-			expReconcilePublicIpErr: errors.New("ReadTag generic error Can not get tag for OscCluster test-system/test-osc"),
+			expReconcilePublicIpErr: errors.New("cannot get tag: ReadTag generic error"),
 		},
 	}
 	for _, pitc := range publicIpTestCases {
@@ -443,12 +443,12 @@ func TestReconcilePublicIpGet(t *testing.T) {
 					if pitc.expTagFound {
 						mockOscTagInterface.
 							EXPECT().
-							ReadTag(gomock.Eq("Name"), gomock.Eq(publicIpName)).
+							ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(publicIpName)).
 							Return(&tag, pitc.expReadTagErr)
 					} else {
 						mockOscTagInterface.
 							EXPECT().
-							ReadTag(gomock.Eq("Name"), gomock.Eq(publicIpName)).
+							ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(publicIpName)).
 							Return(nil, pitc.expReadTagErr)
 					}
 				}
@@ -464,12 +464,12 @@ func TestReconcilePublicIpGet(t *testing.T) {
 			if pitc.expPublicIpFound {
 				mockOscPublicIpInterface.
 					EXPECT().
-					ValidatePublicIpIds(gomock.Eq(publicIpIds)).
+					ValidatePublicIpIds(gomock.Any(), gomock.Eq(publicIpIds)).
 					Return(publicIpIds, pitc.expValidatePublicIpsErr)
 			} else {
 				mockOscPublicIpInterface.
 					EXPECT().
-					ValidatePublicIpIds(gomock.Eq(publicIpIds)).
+					ValidatePublicIpIds(gomock.Any(), gomock.Eq(publicIpIds)).
 					Return(nil, pitc.expValidatePublicIpsErr)
 			}
 			reconcilePublicIp, err := reconcilePublicIp(ctx, clusterScope, mockOscPublicIpInterface, mockOscTagInterface)
@@ -539,7 +539,7 @@ func TestReconcilePublicIpCreate(t *testing.T) {
 			expCreatePublicIpFound:  false,
 			expCreatePublicIpErr:    errors.New("CreatePublicIp generic error"),
 			expReadTagErr:           nil,
-			expReconcilePublicIpErr: errors.New("CreatePublicIp generic error Can not create publicIp for Osccluster test-system/test-osc"),
+			expReconcilePublicIpErr: errors.New("cannot create publicIp: CreatePublicIp generic error"),
 		},
 		{
 			name: "user delete publicIp without cluster-api",
@@ -579,12 +579,12 @@ func TestReconcilePublicIpCreate(t *testing.T) {
 				if pitc.expTagFound {
 					mockOscTagInterface.
 						EXPECT().
-						ReadTag(gomock.Eq("Name"), gomock.Eq(publicIpName)).
+						ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(publicIpName)).
 						Return(&tag, pitc.expReadTagErr)
 				} else {
 					mockOscTagInterface.
 						EXPECT().
-						ReadTag(gomock.Eq("Name"), gomock.Eq(publicIpName)).
+						ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(publicIpName)).
 						Return(nil, pitc.expReadTagErr)
 				}
 				publicIpIds = append(publicIpIds, publicIpId)
@@ -602,12 +602,12 @@ func TestReconcilePublicIpCreate(t *testing.T) {
 					publicIpIds[index] = ""
 					mockOscPublicIpInterface.
 						EXPECT().
-						CreatePublicIp(gomock.Eq(publicIpName)).
+						CreatePublicIp(gomock.Any(), gomock.Eq(publicIpName)).
 						Return(publicIp.PublicIp, pitc.expCreatePublicIpErr)
 				} else {
 					mockOscPublicIpInterface.
 						EXPECT().
-						CreatePublicIp(gomock.Eq(publicIpName)).
+						CreatePublicIp(gomock.Any(), gomock.Eq(publicIpName)).
 						Return(nil, pitc.expCreatePublicIpErr)
 				}
 			}
@@ -617,12 +617,12 @@ func TestReconcilePublicIpCreate(t *testing.T) {
 			if pitc.expPublicIpFound {
 				mockOscPublicIpInterface.
 					EXPECT().
-					ValidatePublicIpIds(gomock.Eq(publicIpIds)).
+					ValidatePublicIpIds(gomock.Any(), gomock.Eq(publicIpIds)).
 					Return(publicIpIds, pitc.expValidatePublicIpsErr)
 			} else {
 				mockOscPublicIpInterface.
 					EXPECT().
-					ValidatePublicIpIds(gomock.Eq(publicIpIds)).
+					ValidatePublicIpIds(gomock.Any(), gomock.Eq(publicIpIds)).
 					Return(nil, pitc.expValidatePublicIpsErr)
 			}
 			reconcilePublicIp, err := reconcilePublicIp(ctx, clusterScope, mockOscPublicIpInterface, mockOscTagInterface)
@@ -665,15 +665,15 @@ func TestReconcileDeletePublicIpDeleteWithoutSpec(t *testing.T) {
 			publicIpIds = append(publicIpIds, publicIpId)
 			mockOscPublicIpInterface.
 				EXPECT().
-				ValidatePublicIpIds(gomock.Eq(publicIpIds)).
+				ValidatePublicIpIds(gomock.Any(), gomock.Eq(publicIpIds)).
 				Return(publicIpIds, pitc.expValidatePublicIpIdsErr)
 			mockOscPublicIpInterface.
 				EXPECT().
-				CheckPublicIpUnlink(gomock.Eq(clockInsideLoop), gomock.Eq(clockLoop), gomock.Eq(publicIpId)).
+				CheckPublicIpUnlink(gomock.Any(), gomock.Eq(clockInsideLoop), gomock.Eq(clockLoop), gomock.Eq(publicIpId)).
 				Return(pitc.expCheckPublicIpUnlinkErr)
 			mockOscPublicIpInterface.
 				EXPECT().
-				DeletePublicIp(gomock.Eq(publicIpId)).
+				DeletePublicIp(gomock.Any(), gomock.Eq(publicIpId)).
 				Return(pitc.expDeletePublicIpErr)
 			networkSpec := clusterScope.GetNetwork()
 			networkSpec.SetPublicIpDefaultValue()
@@ -726,7 +726,7 @@ func TestReconcileDeletePublicIpDelete(t *testing.T) {
 			expValidatePublicIpIdsErr:     nil,
 			expCheckPublicIpUnlinkErr:     nil,
 			expDeletePublicIpErr:          errors.New("DeletePublicIp generic error"),
-			expReconcileDeletePublicIpErr: errors.New("DeletePublicIp generic error Can not delete publicIp for Osccluster test-system/test-osc"),
+			expReconcileDeletePublicIpErr: errors.New("cannot delete publicIp eipalloc-test-publicip-uid: DeletePublicIp generic error"),
 		},
 	}
 	for _, pitc := range publicIpTestCases {
@@ -742,17 +742,17 @@ func TestReconcileDeletePublicIpDelete(t *testing.T) {
 				publicIpIds = append(publicIpIds, publicIpId)
 				mockOscPublicIpInterface.
 					EXPECT().
-					CheckPublicIpUnlink(gomock.Eq(clockInsideLoop), gomock.Eq(clockLoop), gomock.Eq(publicIpId)).
+					CheckPublicIpUnlink(gomock.Any(), gomock.Eq(clockInsideLoop), gomock.Eq(clockLoop), gomock.Eq(publicIpId)).
 					Return(pitc.expCheckPublicIpUnlinkErr)
 				mockOscPublicIpInterface.
 					EXPECT().
-					DeletePublicIp(gomock.Eq(publicIpId)).
+					DeletePublicIp(gomock.Any(), gomock.Eq(publicIpId)).
 					Return(pitc.expDeletePublicIpErr)
 			}
 			if pitc.expPublicIpFound {
 				mockOscPublicIpInterface.
 					EXPECT().
-					ValidatePublicIpIds(gomock.Eq(publicIpIds)).
+					ValidatePublicIpIds(gomock.Any(), gomock.Eq(publicIpIds)).
 					Return(publicIpIds, pitc.expValidatePublicIpIdsErr)
 			} else {
 				if len(publicIpIds) == 0 {
@@ -760,7 +760,7 @@ func TestReconcileDeletePublicIpDelete(t *testing.T) {
 				}
 				mockOscPublicIpInterface.
 					EXPECT().
-					ValidatePublicIpIds(gomock.Eq(publicIpIds)).
+					ValidatePublicIpIds(gomock.Any(), gomock.Eq(publicIpIds)).
 					Return(nil, pitc.expValidatePublicIpIdsErr)
 			}
 
@@ -792,7 +792,7 @@ func TestReconcileDeletePublicIpCheck(t *testing.T) {
 			expPublicIpFound:              true,
 			expValidatePublicIpIdsErr:     nil,
 			expCheckPublicIpUnlinkErr:     errors.New("CheckPublicIpUnlink generic error"),
-			expReconcileDeletePublicIpErr: errors.New("CheckPublicIpUnlink generic error Can not delete publicIp eipalloc-test-publicip-uid for Osccluster test-system/test-osc"),
+			expReconcileDeletePublicIpErr: errors.New("cannot check publicIp eipalloc-test-publicip-uid: CheckPublicIpUnlink generic error"),
 		},
 	}
 	for _, pitc := range publicIpTestCases {
@@ -808,13 +808,13 @@ func TestReconcileDeletePublicIpCheck(t *testing.T) {
 				publicIpIds = append(publicIpIds, publicIpId)
 				mockOscPublicIpInterface.
 					EXPECT().
-					CheckPublicIpUnlink(gomock.Eq(clockInsideLoop), gomock.Eq(clockLoop), gomock.Eq(publicIpId)).
+					CheckPublicIpUnlink(gomock.Any(), gomock.Eq(clockInsideLoop), gomock.Eq(clockLoop), gomock.Eq(publicIpId)).
 					Return(pitc.expCheckPublicIpUnlinkErr)
 			}
 			if pitc.expPublicIpFound {
 				mockOscPublicIpInterface.
 					EXPECT().
-					ValidatePublicIpIds(gomock.Eq(publicIpIds)).
+					ValidatePublicIpIds(gomock.Any(), gomock.Eq(publicIpIds)).
 					Return(publicIpIds, pitc.expValidatePublicIpIdsErr)
 			} else {
 				if len(publicIpIds) == 0 {
@@ -822,7 +822,7 @@ func TestReconcileDeletePublicIpCheck(t *testing.T) {
 				}
 				mockOscPublicIpInterface.
 					EXPECT().
-					ValidatePublicIpIds(gomock.Eq(publicIpIds)).
+					ValidatePublicIpIds(gomock.Any(), gomock.Eq(publicIpIds)).
 					Return(nil, pitc.expValidatePublicIpIdsErr)
 			}
 
@@ -860,7 +860,7 @@ func TestReconcileDeletePublicIpGet(t *testing.T) {
 			spec:                          defaultPublicIpReconcile,
 			expPublicIpFound:              false,
 			expValidatePublicIpIdsErr:     errors.New("ValidatePublicIp generic error"),
-			expReconcileDeletePublicIpErr: errors.New("ValidatePublicIp generic error"),
+			expReconcileDeletePublicIpErr: errors.New("cannot validate publicips: ValidatePublicIp generic error"),
 		},
 		{
 			name:                          "remove finalizer (user delete publicIp without cluster-api)",
@@ -883,7 +883,7 @@ func TestReconcileDeletePublicIpGet(t *testing.T) {
 			if pitc.expPublicIpFound {
 				mockOscPublicIpInterface.
 					EXPECT().
-					ValidatePublicIpIds(gomock.Eq(publicIpIds)).
+					ValidatePublicIpIds(gomock.Any(), gomock.Eq(publicIpIds)).
 					Return(publicIpIds, pitc.expValidatePublicIpIdsErr)
 			} else {
 				if len(publicIpIds) == 0 {
@@ -891,7 +891,7 @@ func TestReconcileDeletePublicIpGet(t *testing.T) {
 				}
 				mockOscPublicIpInterface.
 					EXPECT().
-					ValidatePublicIpIds(gomock.Eq(publicIpIds)).
+					ValidatePublicIpIds(gomock.Any(), gomock.Eq(publicIpIds)).
 					Return(nil, pitc.expValidatePublicIpIdsErr)
 			}
 

--- a/controllers/osccluster_routetable_controller_unit_test.go
+++ b/controllers/osccluster_routetable_controller_unit_test.go
@@ -459,7 +459,7 @@ func TestCheckRouteTableSubnetOscAssociateResourceName(t *testing.T) {
 					},
 				},
 			},
-			expCheckRouteTableSubnetOscAssociateResourceNameErr: errors.New("test-subnet-test-uid subnet does not exist in routeTable"),
+			expCheckRouteTableSubnetOscAssociateResourceNameErr: errors.New("subnet test-subnet-test-uid does not exist in routeTable"),
 		},
 	}
 	for _, rttc := range routeTableTestCases {
@@ -1003,7 +1003,7 @@ func TestReconcilerRouteCreate(t *testing.T) {
 			expCreateRouteErr:            errors.New("CreateRoute generic error"),
 			expGetRouteTableFromRouteErr: nil,
 			expReadTagErr:                nil,
-			expReconcileRouteErr:         errors.New("CreateRoute generic error Can not create route for Osccluster test-system/test-osc"),
+			expReconcileRouteErr:         errors.New("cannot create route: CreateRoute generic error"),
 		},
 	}
 	for _, rttc := range routeTestCases {
@@ -1044,7 +1044,7 @@ func TestReconcilerRouteCreate(t *testing.T) {
 				if rttc.expTagFound {
 					mockOscTagInterface.
 						EXPECT().
-						ReadTag(gomock.Eq("Name"), gomock.Eq(routeTableName)).
+						ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(routeTableName)).
 						Return(&tag, rttc.expReadTagErr)
 				}
 				routeTablesRef.ResourceMap[routeTableName] = routeTableId
@@ -1074,23 +1074,23 @@ func TestReconcilerRouteCreate(t *testing.T) {
 					if rttc.expRouteFound {
 						mockOscRouteTableInterface.
 							EXPECT().
-							GetRouteTableFromRoute(gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
+							GetRouteTableFromRoute(gomock.Any(), gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
 							Return(&readRouteTable[0], rttc.expGetRouteTableFromRouteErr)
 					} else {
 						mockOscRouteTableInterface.
 							EXPECT().
-							GetRouteTableFromRoute(gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
+							GetRouteTableFromRoute(gomock.Any(), gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
 							Return(nil, rttc.expGetRouteTableFromRouteErr)
 					}
 					if rttc.expCreateRouteFound {
 						mockOscRouteTableInterface.
 							EXPECT().
-							CreateRoute(gomock.Eq(destinationIpRange), gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
+							CreateRoute(gomock.Any(), gomock.Eq(destinationIpRange), gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
 							Return(route.RouteTable, rttc.expCreateRouteErr)
 					} else {
 						mockOscRouteTableInterface.
 							EXPECT().
-							CreateRoute(gomock.Eq(destinationIpRange), gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
+							CreateRoute(gomock.Any(), gomock.Eq(destinationIpRange), gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
 							Return(nil, rttc.expCreateRouteErr)
 					}
 					reconcileRoute, err := reconcileRoute(ctx, clusterScope, routeSpec, routeTableName, mockOscRouteTableInterface)
@@ -1150,7 +1150,7 @@ func TestReconcileRouteGet(t *testing.T) {
 			expNatServiceFound:           true,
 			expGetRouteTableFromRouteErr: errors.New("GetRouteTableFromRoute generic error"),
 			expReadTagErr:                nil,
-			expReconcileRouteErr:         errors.New("GetRouteTableFromRoute generic error"),
+			expReconcileRouteErr:         errors.New("cannot get route table: GetRouteTableFromRoute generic error"),
 		},
 	}
 	for _, rttc := range routeTestCases {
@@ -1192,7 +1192,7 @@ func TestReconcileRouteGet(t *testing.T) {
 				if rttc.expTagFound {
 					mockOscTagInterface.
 						EXPECT().
-						ReadTag(gomock.Eq("Name"), gomock.Eq(routeTableName)).
+						ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(routeTableName)).
 						Return(&tag, rttc.expReadTagErr)
 				}
 				associateRouteTableId = routeTableId
@@ -1220,12 +1220,12 @@ func TestReconcileRouteGet(t *testing.T) {
 					if rttc.expRouteFound {
 						mockOscRouteTableInterface.
 							EXPECT().
-							GetRouteTableFromRoute(gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
+							GetRouteTableFromRoute(gomock.Any(), gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
 							Return(&readRouteTable[0], rttc.expGetRouteTableFromRouteErr)
 					} else {
 						mockOscRouteTableInterface.
 							EXPECT().
-							GetRouteTableFromRoute(gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
+							GetRouteTableFromRoute(gomock.Any(), gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
 							Return(nil, rttc.expGetRouteTableFromRouteErr)
 					}
 					reconcileRoute, err := reconcileRoute(ctx, clusterScope, routeSpec, routeTableName, mockOscRouteTableInterface)
@@ -1301,7 +1301,7 @@ func TestReconcileRouteResourceId(t *testing.T) {
 				if rttc.expTagFound {
 					mockOscTagInterface.
 						EXPECT().
-						ReadTag(gomock.Eq("Name"), gomock.Eq(routeTableName)).
+						ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(routeTableName)).
 						Return(&tag, rttc.expReadTagErr)
 				}
 				routesSpec := routeTableSpec.Routes
@@ -1382,7 +1382,7 @@ func TestReconcileRouteTableCreate(t *testing.T) {
 			expGetRouteTableFromRouteErr:     nil,
 			expGetRouteTableIdsFromNetIdsErr: nil,
 			expReadTagErr:                    nil,
-			expReconcileRouteTableErr:        errors.New("CreateRoute generic error Can not create route for Osccluster test-system/test-osc"),
+			expReconcileRouteTableErr:        errors.New("cannot create route: CreateRoute generic error"),
 		},
 	}
 	for _, rttc := range routeTestCases {
@@ -1440,12 +1440,12 @@ func TestReconcileRouteTableCreate(t *testing.T) {
 				if rttc.expTagFound {
 					mockOscTagInterface.
 						EXPECT().
-						ReadTag(gomock.Eq("Name"), gomock.Eq(routeTableName)).
+						ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(routeTableName)).
 						Return(&tag, rttc.expReadTagErr)
 				} else {
 					mockOscTagInterface.
 						EXPECT().
-						ReadTag(gomock.Eq("Name"), gomock.Eq(routeTableName)).
+						ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(routeTableName)).
 						Return(nil, rttc.expReadTagErr)
 				}
 				routeTableIds = append(routeTableIds, routeTableId)
@@ -1482,12 +1482,12 @@ func TestReconcileRouteTableCreate(t *testing.T) {
 					if rttc.expRouteTableFound {
 						mockOscRouteTableInterface.
 							EXPECT().
-							GetRouteTableIdsFromNetIds(gomock.Eq(netId)).
+							GetRouteTableIdsFromNetIds(gomock.Any(), gomock.Eq(netId)).
 							Return(routeTableIds, rttc.expGetRouteTableIdsFromNetIdsErr)
 					} else {
 						mockOscRouteTableInterface.
 							EXPECT().
-							GetRouteTableIdsFromNetIds(gomock.Eq(netId)).
+							GetRouteTableIdsFromNetIds(gomock.Any(), gomock.Eq(netId)).
 							Return(nil, rttc.expGetRouteTableIdsFromNetIdsErr)
 					}
 					if rttc.expCreateRouteTableFound {
@@ -1495,24 +1495,24 @@ func TestReconcileRouteTableCreate(t *testing.T) {
 						routeTablesRef.ResourceMap[routeTableName] = routeTableId
 						mockOscRouteTableInterface.
 							EXPECT().
-							CreateRouteTable(gomock.Eq(netId), gomock.Eq(clusterName), gomock.Eq(routeTableName)).
+							CreateRouteTable(gomock.Any(), gomock.Eq(netId), gomock.Eq(clusterName), gomock.Eq(routeTableName)).
 							Return(routeTable.RouteTable, rttc.expCreateRouteTableErr)
 					} else {
 						mockOscRouteTableInterface.
 							EXPECT().
-							CreateRouteTable(gomock.Eq(netId), gomock.Eq(netName), gomock.Eq(routeTableName)).
+							CreateRouteTable(gomock.Any(), gomock.Eq(netId), gomock.Eq(netName), gomock.Eq(routeTableName)).
 							Return(nil, rttc.expCreateRouteTableErr)
 					}
 
 					if rttc.expLinkRouteTableFound {
 						mockOscRouteTableInterface.
 							EXPECT().
-							LinkRouteTable(gomock.Eq(routeTableId), gomock.Eq(subnetId)).
+							LinkRouteTable(gomock.Any(), gomock.Eq(routeTableId), gomock.Eq(subnetId)).
 							Return(*linkRouteTable.LinkRouteTableId, rttc.expLinkRouteTableErr)
 					} else {
 						mockOscRouteTableInterface.
 							EXPECT().
-							LinkRouteTable(gomock.Eq(routeTableId), gomock.Eq(subnetId)).
+							LinkRouteTable(gomock.Any(), gomock.Eq(routeTableId), gomock.Eq(subnetId)).
 							Return("", rttc.expLinkRouteTableErr)
 					}
 
@@ -1534,23 +1534,23 @@ func TestReconcileRouteTableCreate(t *testing.T) {
 						if rttc.expRouteFound {
 							mockOscRouteTableInterface.
 								EXPECT().
-								GetRouteTableFromRoute(gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
+								GetRouteTableFromRoute(gomock.Any(), gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
 								Return(&readRouteTable[0], rttc.expGetRouteTableFromRouteErr)
 						} else {
 							mockOscRouteTableInterface.
 								EXPECT().
-								GetRouteTableFromRoute(gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
+								GetRouteTableFromRoute(gomock.Any(), gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
 								Return(nil, rttc.expGetRouteTableFromRouteErr)
 						}
 						if rttc.expCreateRouteFound {
 							mockOscRouteTableInterface.
 								EXPECT().
-								CreateRoute(gomock.Eq(destinationIpRange), gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
+								CreateRoute(gomock.Any(), gomock.Eq(destinationIpRange), gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
 								Return(route.RouteTable, rttc.expCreateRouteErr)
 						} else {
 							mockOscRouteTableInterface.
 								EXPECT().
-								CreateRoute(gomock.Eq(destinationIpRange), gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
+								CreateRoute(gomock.Any(), gomock.Eq(destinationIpRange), gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
 								Return(nil, rttc.expCreateRouteErr)
 						}
 					}
@@ -1606,7 +1606,7 @@ func TestReconcileRouteTableGet(t *testing.T) {
 			expTagFound:                      false,
 			expGetRouteTableIdsFromNetIdsErr: errors.New("GetRouteTableIdsFromNetIds generic errors"),
 			expReadTagErr:                    nil,
-			expReconcileRouteTableErr:        errors.New("GetRouteTableIdsFromNetIds generic errors"),
+			expReconcileRouteTableErr:        errors.New("list route tables: GetRouteTableIdsFromNetIds generic errors"),
 		},
 		{
 			name:                             "create routetable with natservice (first time reconcile loop)",
@@ -1674,7 +1674,7 @@ func TestReconcileRouteTableGet(t *testing.T) {
 						if rttc.expRouteTableFound {
 							mockOscTagInterface.
 								EXPECT().
-								ReadTag(gomock.Eq("Name"), gomock.Eq(routeTableName)).
+								ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(routeTableName)).
 								Return(&tag, rttc.expReadTagErr)
 						}
 					}
@@ -1688,12 +1688,12 @@ func TestReconcileRouteTableGet(t *testing.T) {
 					if rttc.expRouteTableFound {
 						mockOscRouteTableInterface.
 							EXPECT().
-							GetRouteTableIdsFromNetIds(gomock.Eq(netId)).
+							GetRouteTableIdsFromNetIds(gomock.Any(), gomock.Eq(netId)).
 							Return(routeTableIds, rttc.expGetRouteTableIdsFromNetIdsErr)
 					} else {
 						mockOscRouteTableInterface.
 							EXPECT().
-							GetRouteTableIdsFromNetIds(gomock.Eq(netId)).
+							GetRouteTableIdsFromNetIds(gomock.Any(), gomock.Eq(netId)).
 							Return(nil, rttc.expGetRouteTableIdsFromNetIdsErr)
 					}
 				}
@@ -1737,7 +1737,7 @@ func TestReconcileRouteTableResourceId(t *testing.T) {
 			expNetFound:                      true,
 			expGetRouteTableIdsFromNetIdsErr: nil,
 			expReadTagErr:                    errors.New("ReadTag generic error"),
-			expReconcileRouteTableErr:        errors.New("ReadTag generic error Can not get tag for OscCluster test-system/test-osc"),
+			expReconcileRouteTableErr:        errors.New("cannot get tag: ReadTag generic error"),
 		},
 	}
 	for _, rttc := range routeTestCases {
@@ -1760,13 +1760,13 @@ func TestReconcileRouteTableResourceId(t *testing.T) {
 					routeTableIds = append(routeTableIds, routeTableId)
 					mockOscTagInterface.
 						EXPECT().
-						ReadTag(gomock.Eq("Name"), gomock.Eq(routeTableName)).
+						ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(routeTableName)).
 						Return(nil, rttc.expReadTagErr)
 				}
 
 				mockOscRouteTableInterface.
 					EXPECT().
-					GetRouteTableIdsFromNetIds(netId).
+					GetRouteTableIdsFromNetIds(gomock.Any(), netId).
 					Return(routeTableIds, rttc.expGetRouteTableIdsFromNetIdsErr)
 			}
 			reconcileRouteTable, err := reconcileRouteTable(ctx, clusterScope, mockOscRouteTableInterface, mockOscTagInterface)
@@ -1831,7 +1831,7 @@ func TestReconcileCreateRouteTable(t *testing.T) {
 			expGetRouteTableIdsFromNetIdsErr: nil,
 			expTagFound:                      false,
 			expReadTagErr:                    nil,
-			expReconcileRouteTableErr:        errors.New("CreateRouteTable generic error Can not create routetable for Osccluster test-system/test-osc"),
+			expReconcileRouteTableErr:        errors.New("cannot create routetable: CreateRouteTable generic error"),
 		},
 	}
 	for _, rttc := range routeTestCases {
@@ -1863,12 +1863,12 @@ func TestReconcileCreateRouteTable(t *testing.T) {
 				if rttc.expTagFound {
 					mockOscTagInterface.
 						EXPECT().
-						ReadTag(gomock.Eq("Name"), gomock.Eq(routeTableName)).
+						ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(routeTableName)).
 						Return(&tag, rttc.expReadTagErr)
 				} else {
 					mockOscTagInterface.
 						EXPECT().
-						ReadTag(gomock.Eq("Name"), gomock.Eq(routeTableName)).
+						ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(routeTableName)).
 						Return(nil, rttc.expReadTagErr)
 				}
 
@@ -1879,12 +1879,12 @@ func TestReconcileCreateRouteTable(t *testing.T) {
 					subnetRef.ResourceMap[subnetName] = subnetId
 					mockOscRouteTableInterface.
 						EXPECT().
-						GetRouteTableIdsFromNetIds(gomock.Eq(netId)).
+						GetRouteTableIdsFromNetIds(gomock.Any(), gomock.Eq(netId)).
 						Return(routeTableIds, rttc.expGetRouteTableIdsFromNetIdsErr)
 
 					mockOscRouteTableInterface.
 						EXPECT().
-						CreateRouteTable(gomock.Eq(netId), gomock.Eq(clusterName), gomock.Eq(routeTableName)).
+						CreateRouteTable(gomock.Any(), gomock.Eq(netId), gomock.Eq(clusterName), gomock.Eq(routeTableName)).
 						Return(nil, rttc.expCreateRouteTableErr)
 				}
 				reconcileRouteTable, err := reconcileRouteTable(ctx, clusterScope, mockOscRouteTableInterface, mockOscTagInterface)
@@ -1923,7 +1923,7 @@ func TestReconcileRouteTableLink(t *testing.T) {
 			expLinkRouteTableErr:             errors.New("LinkRouteTable generic error"),
 			expGetRouteTableIdsFromNetIdsErr: nil,
 			expReadTagErr:                    nil,
-			expReconcileRouteTableErr:        errors.New("LinkRouteTable generic error Can not link routetable with net for Osccluster test-system/test-osc"),
+			expReconcileRouteTableErr:        errors.New("cannot link routetable with net: LinkRouteTable generic error"),
 		},
 		{
 			name:                             "failed to get subnet",
@@ -1965,12 +1965,12 @@ func TestReconcileRouteTableLink(t *testing.T) {
 				if rttc.expTagFound {
 					mockOscTagInterface.
 						EXPECT().
-						ReadTag(gomock.Eq("Name"), gomock.Eq(routeTableName)).
+						ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(routeTableName)).
 						Return(&tag, rttc.expReadTagErr)
 				} else {
 					mockOscTagInterface.
 						EXPECT().
-						ReadTag(gomock.Eq("Name"), gomock.Eq(routeTableName)).
+						ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(routeTableName)).
 						Return(nil, rttc.expReadTagErr)
 				}
 				subnetsSpec := routeTableSpec.Subnets
@@ -1989,17 +1989,17 @@ func TestReconcileRouteTableLink(t *testing.T) {
 
 					mockOscRouteTableInterface.
 						EXPECT().
-						CreateRouteTable(gomock.Eq(netId), gomock.Eq(clusterName), gomock.Eq(routeTableName)).
+						CreateRouteTable(gomock.Any(), gomock.Eq(netId), gomock.Eq(clusterName), gomock.Eq(routeTableName)).
 						Return(routeTable.RouteTable, rttc.expCreateRouteTableErr)
 					if rttc.expLinkRouteTableFound {
 						mockOscRouteTableInterface.
 							EXPECT().
-							LinkRouteTable(gomock.Eq(routeTableId), gomock.Eq(subnetId)).
+							LinkRouteTable(gomock.Any(), gomock.Eq(routeTableId), gomock.Eq(subnetId)).
 							Return("", rttc.expLinkRouteTableErr)
 					}
 					mockOscRouteTableInterface.
 						EXPECT().
-						GetRouteTableIdsFromNetIds(gomock.Eq(netId)).
+						GetRouteTableIdsFromNetIds(gomock.Any(), gomock.Eq(netId)).
 						Return(nil, rttc.expGetRouteTableIdsFromNetIdsErr)
 				}
 				reconcileRouteTable, err := reconcileRouteTable(ctx, clusterScope, mockOscRouteTableInterface, mockOscTagInterface)
@@ -2064,7 +2064,7 @@ func TestReconcileDeleteRouteDelete(t *testing.T) {
 			expNatServiceFound:           false,
 			expDeleteRouteErr:            errors.New("DeleteRoute generic error"),
 			expGetRouteTableFromRouteErr: nil,
-			expReconcileDeleteRouteErr:   errors.New("DeleteRoute generic error Can not delete route for Osccluster test-system/test-osc"),
+			expReconcileDeleteRouteErr:   errors.New("cannot delete route: DeleteRoute generic error"),
 		},
 	}
 	for _, rttc := range routeTestCases {
@@ -2128,17 +2128,17 @@ func TestReconcileDeleteRouteDelete(t *testing.T) {
 					if rttc.expRouteFound {
 						mockOscRouteTableInterface.
 							EXPECT().
-							GetRouteTableFromRoute(gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
+							GetRouteTableFromRoute(gomock.Any(), gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
 							Return(&readRouteTable[0], rttc.expGetRouteTableFromRouteErr)
 					} else {
 						mockOscRouteTableInterface.
 							EXPECT().
-							GetRouteTableFromRoute(gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
+							GetRouteTableFromRoute(gomock.Any(), gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
 							Return(nil, rttc.expGetRouteTableFromRouteErr)
 					}
 					mockOscRouteTableInterface.
 						EXPECT().
-						DeleteRoute(gomock.Eq(destinationIpRange), gomock.Eq(routeTableId)).
+						DeleteRoute(gomock.Any(), gomock.Eq(destinationIpRange), gomock.Eq(routeTableId)).
 						Return(rttc.expDeleteRouteErr)
 
 					reconcileDeleteRoute, err := reconcileDeleteRoute(ctx, clusterScope, routeSpec, routeTableName, mockOscRouteTableInterface)
@@ -2172,7 +2172,7 @@ func TestReconcileDeleteRouteGet(t *testing.T) {
 			expInternetServiceFound:      true,
 			expNatServiceFound:           false,
 			expGetRouteTableFromRouteErr: errors.New("GetRouteTable generic error"),
-			expReconcileDeleteRouteErr:   errors.New("GetRouteTable generic error"),
+			expReconcileDeleteRouteErr:   errors.New("checking route table: GetRouteTable generic error"),
 		},
 		{
 			name:                         "remove finalizer (user delete route without cluster-api)",
@@ -2245,12 +2245,12 @@ func TestReconcileDeleteRouteGet(t *testing.T) {
 					if rttc.expRouteFound {
 						mockOscRouteTableInterface.
 							EXPECT().
-							GetRouteTableFromRoute(gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
+							GetRouteTableFromRoute(gomock.Any(), gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
 							Return(&readRouteTable[0], rttc.expGetRouteTableFromRouteErr)
 					} else {
 						mockOscRouteTableInterface.
 							EXPECT().
-							GetRouteTableFromRoute(gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
+							GetRouteTableFromRoute(gomock.Any(), gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
 							Return(nil, rttc.expGetRouteTableFromRouteErr)
 					}
 
@@ -2404,16 +2404,16 @@ func TestReconcileDeleteRouteTableDeleteWithoutSpec(t *testing.T) {
 			clusterScope.SetLinkRouteTablesRef(linkRouteTableRef)
 			mockOscRouteTableInterface.
 				EXPECT().
-				GetRouteTableIdsFromNetIds(gomock.Eq(netId)).
+				GetRouteTableIdsFromNetIds(gomock.Any(), gomock.Eq(netId)).
 				Return(routeTableIds, rttc.expGetRouteTableIdsFromNetIdsErr)
 			mockOscRouteTableInterface.
 				EXPECT().
-				UnlinkRouteTable(gomock.Eq(linkRouteTableId)).
+				UnlinkRouteTable(gomock.Any(), gomock.Eq(linkRouteTableId)).
 				Return(rttc.expUnlinkRouteTableErr)
 
 			mockOscRouteTableInterface.
 				EXPECT().
-				DeleteRouteTable(gomock.Eq(routeTableId)).
+				DeleteRouteTable(gomock.Any(), gomock.Eq(routeTableId)).
 				Return(rttc.expDeleteRouteTableErr)
 
 			destinationIpRange := "0.0.0.0/0"
@@ -2441,12 +2441,12 @@ func TestReconcileDeleteRouteTableDeleteWithoutSpec(t *testing.T) {
 			readRouteTable := *readRouteTables.RouteTables
 			mockOscRouteTableInterface.
 				EXPECT().
-				GetRouteTableFromRoute(gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
+				GetRouteTableFromRoute(gomock.Any(), gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
 				Return(&readRouteTable[0], rttc.expGetRouteTableFromRouteErr)
 
 			mockOscRouteTableInterface.
 				EXPECT().
-				DeleteRoute(gomock.Eq(destinationIpRange), gomock.Eq(routeTableId)).
+				DeleteRoute(gomock.Any(), gomock.Eq(destinationIpRange), gomock.Eq(routeTableId)).
 				Return(rttc.expDeleteRouteErr)
 			reconcileDeleteRouteTable, err := reconcileDeleteRouteTable(ctx, clusterScope, mockOscRouteTableInterface)
 			if rttc.expReconcileDeleteRouteTableErr != nil {
@@ -2507,7 +2507,7 @@ func TestReconcileDeleteRouteTableDelete(t *testing.T) {
 			expDeleteRouteTableErr:           errors.New("DeleteRoutetable generic error"),
 			expGetRouteTableFromRouteErr:     nil,
 			expGetRouteTableIdsFromNetIdsErr: nil,
-			expReconcileDeleteRouteTableErr:  errors.New("DeleteRoutetable generic error Can not delete routeTable for Osccluster test-system/test-osc"),
+			expReconcileDeleteRouteTableErr:  errors.New("cannot delete routeTable: DeleteRoutetable generic error"),
 		},
 	}
 	for _, rttc := range routeTableTestCases {
@@ -2572,21 +2572,21 @@ func TestReconcileDeleteRouteTableDelete(t *testing.T) {
 				if rttc.expRouteTableFound {
 					mockOscRouteTableInterface.
 						EXPECT().
-						GetRouteTableIdsFromNetIds(gomock.Eq(netId)).
+						GetRouteTableIdsFromNetIds(gomock.Any(), gomock.Eq(netId)).
 						Return(routeTableIds, rttc.expGetRouteTableIdsFromNetIdsErr)
 				} else {
 					mockOscRouteTableInterface.
 						EXPECT().
-						GetRouteTableIdsFromNetIds(gomock.Eq(netId)).
+						GetRouteTableIdsFromNetIds(gomock.Any(), gomock.Eq(netId)).
 						Return(nil, rttc.expGetRouteTableIdsFromNetIdsErr)
 				}
 				mockOscRouteTableInterface.
 					EXPECT().
-					UnlinkRouteTable(gomock.Eq(linkRouteTableId)).
+					UnlinkRouteTable(gomock.Any(), gomock.Eq(linkRouteTableId)).
 					Return(rttc.expUnlinkRouteTableErr)
 				mockOscRouteTableInterface.
 					EXPECT().
-					DeleteRouteTable(gomock.Eq(routeTableId)).
+					DeleteRouteTable(gomock.Any(), gomock.Eq(routeTableId)).
 					Return(rttc.expDeleteRouteTableErr)
 
 				routesSpec := routeTableSpec.Routes
@@ -2618,17 +2618,17 @@ func TestReconcileDeleteRouteTableDelete(t *testing.T) {
 					if rttc.expRouteTableFound {
 						mockOscRouteTableInterface.
 							EXPECT().
-							GetRouteTableFromRoute(gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
+							GetRouteTableFromRoute(gomock.Any(), gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
 							Return(&readRouteTable[0], rttc.expGetRouteTableFromRouteErr)
 					} else {
 						mockOscRouteTableInterface.
 							EXPECT().
-							GetRouteTableFromRoute(gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
+							GetRouteTableFromRoute(gomock.Any(), gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
 							Return(nil, rttc.expGetRouteTableFromRouteErr)
 					}
 					mockOscRouteTableInterface.
 						EXPECT().
-						DeleteRoute(gomock.Eq(destinationIpRange), gomock.Eq(routeTableId)).
+						DeleteRoute(gomock.Any(), gomock.Eq(destinationIpRange), gomock.Eq(routeTableId)).
 						Return(rttc.expDeleteRouteErr)
 				}
 			}
@@ -2719,12 +2719,12 @@ func TestReconcileDeleteRouteTableGet(t *testing.T) {
 				if rttc.expRouteTableFound {
 					mockOscRouteTableInterface.
 						EXPECT().
-						GetRouteTableIdsFromNetIds(gomock.Eq(netId)).
+						GetRouteTableIdsFromNetIds(gomock.Any(), gomock.Eq(netId)).
 						Return([]string{routeTableId}, rttc.expGetRouteTableIdsFromNetIdsErr)
 				} else {
 					mockOscRouteTableInterface.
 						EXPECT().
-						GetRouteTableIdsFromNetIds(gomock.Eq(netId)).
+						GetRouteTableIdsFromNetIds(gomock.Any(), gomock.Eq(netId)).
 						Return(nil, rttc.expGetRouteTableIdsFromNetIdsErr)
 				}
 			}
@@ -2757,7 +2757,7 @@ func TestReconcileDeleteRouteTableUnlink(t *testing.T) {
 			expDeleteRouteErr:                nil,
 			expGetRouteTableFromRouteErr:     nil,
 			expGetRouteTableIdsFromNetIdsErr: nil,
-			expReconcileDeleteRouteTableErr:  errors.New("UnlinkRouteTable generic error Can not unlink routeTable for Osccluster test-system/test-osc"),
+			expReconcileDeleteRouteTableErr:  errors.New("cannot unlink routeTable: UnlinkRouteTable generic error"),
 		},
 	}
 	for _, rttc := range routeTableTestCases {
@@ -2803,12 +2803,12 @@ func TestReconcileDeleteRouteTableUnlink(t *testing.T) {
 				clusterScope.SetLinkRouteTablesRef(linkRouteTableRef)
 				mockOscRouteTableInterface.
 					EXPECT().
-					GetRouteTableIdsFromNetIds(gomock.Eq(netId)).
+					GetRouteTableIdsFromNetIds(gomock.Any(), gomock.Eq(netId)).
 					Return([]string{routeTableId}, rttc.expGetRouteTableIdsFromNetIdsErr)
 
 				mockOscRouteTableInterface.
 					EXPECT().
-					UnlinkRouteTable(gomock.Eq(linkRouteTableId)).
+					UnlinkRouteTable(gomock.Any(), gomock.Eq(linkRouteTableId)).
 					Return(rttc.expUnlinkRouteTableErr)
 
 				routesSpec := routeTableSpec.Routes
@@ -2837,11 +2837,11 @@ func TestReconcileDeleteRouteTableUnlink(t *testing.T) {
 					readRouteTable := *readRouteTables.RouteTables
 					mockOscRouteTableInterface.
 						EXPECT().
-						GetRouteTableFromRoute(gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
+						GetRouteTableFromRoute(gomock.Any(), gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
 						Return(&readRouteTable[0], rttc.expGetRouteTableFromRouteErr)
 					mockOscRouteTableInterface.
 						EXPECT().
-						DeleteRoute(gomock.Eq(destinationIpRange), gomock.Eq(routeTableId)).
+						DeleteRoute(gomock.Any(), gomock.Eq(destinationIpRange), gomock.Eq(routeTableId)).
 						Return(rttc.expDeleteRouteErr).AnyTimes()
 				}
 			}
@@ -2872,7 +2872,7 @@ func TestReconcileDeleteRouteDeleteRouteTable(t *testing.T) {
 			expDeleteRouteErr:                errors.New("DeleteRoute generic error"),
 			expGetRouteTableFromRouteErr:     nil,
 			expGetRouteTableIdsFromNetIdsErr: nil,
-			expReconcileDeleteRouteTableErr:  errors.New("DeleteRoute generic error Can not delete route for Osccluster test-system/test-osc"),
+			expReconcileDeleteRouteTableErr:  errors.New("cannot delete route: DeleteRoute generic error"),
 		},
 	}
 	for _, rttc := range routeTableTestCases {
@@ -2919,7 +2919,7 @@ func TestReconcileDeleteRouteDeleteRouteTable(t *testing.T) {
 
 				mockOscRouteTableInterface.
 					EXPECT().
-					GetRouteTableIdsFromNetIds(gomock.Eq(netId)).
+					GetRouteTableIdsFromNetIds(gomock.Any(), gomock.Eq(netId)).
 					Return([]string{routeTableId}, rttc.expGetRouteTableIdsFromNetIdsErr)
 
 				routesSpec := routeTableSpec.Routes
@@ -2948,11 +2948,11 @@ func TestReconcileDeleteRouteDeleteRouteTable(t *testing.T) {
 					readRouteTable := *readRouteTables.RouteTables
 					mockOscRouteTableInterface.
 						EXPECT().
-						GetRouteTableFromRoute(gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
+						GetRouteTableFromRoute(gomock.Any(), gomock.Eq(associateRouteTableId), gomock.Eq(resourceId), gomock.Eq(resourceType)).
 						Return(&readRouteTable[0], rttc.expGetRouteTableFromRouteErr)
 					mockOscRouteTableInterface.
 						EXPECT().
-						DeleteRoute(destinationIpRange, routeTableId).
+						DeleteRoute(gomock.Any(), destinationIpRange, routeTableId).
 						Return(rttc.expDeleteRouteErr)
 				}
 			}

--- a/controllers/osccluster_subnet_controller.go
+++ b/controllers/osccluster_subnet_controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/outscale/cluster-api-provider-outscale/cloud/scope"
 	"github.com/outscale/cluster-api-provider-outscale/cloud/services/net"
 	tag "github.com/outscale/cluster-api-provider-outscale/cloud/tag"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -51,19 +52,16 @@ func checkSubnetFormatParameters(clusterScope *scope.ClusterScope) (string, erro
 	networkSpec.SetSubnetSubregionNameDefaultValue()
 	for _, subnetSpec := range subnetsSpec {
 		subnetName := subnetSpec.Name + "-" + clusterScope.GetUID()
-		clusterScope.V(2).Info("Check subnet name parameters")
 		subnetTagName, err := tag.ValidateTagNameValue(subnetName)
 		if err != nil {
 			return subnetTagName, err
 		}
 		subnetIpRange := subnetSpec.IpSubnetRange
-		clusterScope.V(2).Info("Check subnet ipsubnetrange parameters")
 		_, err = infrastructurev1beta1.ValidateCidr(subnetIpRange)
 		if err != nil {
 			return subnetTagName, err
 		}
 		subnetSubregionName := subnetSpec.SubregionName
-		clusterScope.V(2).Info("Check subnet subregion parameters")
 		_, err = infrastructurev1beta1.ValidateSubregionName(subnetSubregionName)
 		if err != nil {
 			return subnetTagName, err
@@ -79,7 +77,6 @@ func checkSubnetOscDuplicateName(clusterScope *scope.ClusterScope) error {
 	for _, subnetSpec := range subnetsSpec {
 		resourceNameList = append(resourceNameList, subnetSpec.Name)
 	}
-	clusterScope.V(2).Info("Check unique subnet")
 	duplicateResourceErr := alertDuplicate(resourceNameList)
 	if duplicateResourceErr != nil {
 		return duplicateResourceErr
@@ -90,6 +87,7 @@ func checkSubnetOscDuplicateName(clusterScope *scope.ClusterScope) error {
 
 // reconcileSubnet reconcile the subnet of the cluster.
 func reconcileSubnet(ctx context.Context, clusterScope *scope.ClusterScope, subnetSvc net.OscSubnetInterface, tagSvc tag.OscTagInterface) (reconcile.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
 	netSpec := clusterScope.GetNet()
 	netSpec.SetDefaultValue()
 	netName := netSpec.Name + "-" + clusterScope.GetUID()
@@ -103,23 +101,23 @@ func reconcileSubnet(ctx context.Context, clusterScope *scope.ClusterScope, subn
 	networkSpec := clusterScope.GetNetwork()
 	clusterName := networkSpec.ClusterName + "-" + clusterScope.GetUID()
 	var subnetIds []string
-	clusterScope.V(2).Info("Check if the desired subnet exist")
-	subnetIds, err = subnetSvc.GetSubnetIdsFromNetIds(netId)
-	clusterScope.V(4).Info("Get subnetIds", "subnetIds", subnetIds)
+	log.V(4).Info("Checking subnet")
+	subnetIds, err = subnetSvc.GetSubnetIdsFromNetIds(ctx, netId)
+	log.V(4).Info("Get subnetIds", "subnetIds", subnetIds)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-	clusterScope.V(4).Info("Number of subnet", "subnet_length", len(subnetsSpec))
+	log.V(4).Info("Number of subnet", "subnet_length", len(subnetsSpec))
 	for _, subnetSpec := range subnetsSpec {
 		subnetName := subnetSpec.Name + "-" + clusterScope.GetUID()
 		tagKey := "Name"
 		tagValue := subnetName
-		tag, err := tagSvc.ReadTag(tagKey, tagValue)
+		tag, err := tagSvc.ReadTag(ctx, tagKey, tagValue)
 		if err != nil {
-			return reconcile.Result{}, fmt.Errorf("%w Can not get tag for OscCluster %s/%s", err, clusterScope.GetNamespace(), clusterScope.GetName())
+			return reconcile.Result{}, fmt.Errorf("cannot get tag: %w", err)
 		}
 		subnetId := subnetSpec.ResourceId
-		clusterScope.V(4).Info("Get subnetId", "subnetId", subnetId)
+		log.V(4).Info("Get subnetId", "subnetId", subnetId)
 		if len(subnetRef.ResourceMap) == 0 {
 			subnetRef.ResourceMap = make(map[string]string)
 		}
@@ -131,10 +129,10 @@ func reconcileSubnet(ctx context.Context, clusterScope *scope.ClusterScope, subn
 			subnetSpec.ResourceId = subnetRef.ResourceMap[subnetName]
 		}
 		if !Contains(subnetIds, subnetId) && tag == nil {
-			clusterScope.V(2).Info("Create the desired subnet", "subnetName", subnetName)
-			subnet, err := subnetSvc.CreateSubnet(subnetSpec, netId, clusterName, subnetName)
+			log.V(2).Info("Creating subnet", "subnetName", subnetName)
+			subnet, err := subnetSvc.CreateSubnet(ctx, subnetSpec, netId, clusterName, subnetName)
 			if err != nil {
-				return reconcile.Result{}, fmt.Errorf("%w Can not create subnet for Osccluster %s/%s", err, clusterScope.GetNamespace(), clusterScope.GetName())
+				return reconcile.Result{}, fmt.Errorf("cannot create subnet: %w", err)
 			}
 			subnetRef.ResourceMap[subnetName] = subnet.GetSubnetId()
 			subnetSpec.ResourceId = subnet.GetSubnetId()
@@ -145,6 +143,7 @@ func reconcileSubnet(ctx context.Context, clusterScope *scope.ClusterScope, subn
 
 // reconcileDeleteSubnet reconcile the destruction of the Subnet of the cluster.
 func reconcileDeleteSubnet(ctx context.Context, clusterScope *scope.ClusterScope, subnetSvc net.OscSubnetInterface) (reconcile.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
 	osccluster := clusterScope.OscCluster
 	subnetsSpec := clusterScope.GetSubnet()
 	netSpec := clusterScope.GetNet()
@@ -160,23 +159,23 @@ func reconcileDeleteSubnet(ctx context.Context, clusterScope *scope.ClusterScope
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-	subnetIds, err := subnetSvc.GetSubnetIdsFromNetIds(netId)
+	subnetIds, err := subnetSvc.GetSubnetIdsFromNetIds(ctx, netId)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-	clusterScope.V(4).Info("Number of subnet", "subnet_length", len(subnetsSpec))
+	log.V(4).Info("Number of subnet", "subnet_length", len(subnetsSpec))
 	for _, subnetSpec := range subnetsSpec {
 		subnetId := subnetSpec.ResourceId
 		subnetName := subnetSpec.Name + "-" + clusterScope.GetUID()
 		if !Contains(subnetIds, subnetId) {
-			clusterScope.V(2).Info("the desired subnet does not exist anymore", "subnetName", subnetName)
+			log.V(2).Info("subnet does not exist anymore", "subnetName", subnetName)
 			controllerutil.RemoveFinalizer(osccluster, "oscclusters.infrastructure.cluster.x-k8s.io")
 			return reconcile.Result{}, nil
 		}
-		err = subnetSvc.DeleteSubnet(subnetId)
+		log.V(2).Info("Deleting subnet", "subnetName", subnetName)
+		err = subnetSvc.DeleteSubnet(ctx, subnetId)
 		if err != nil {
-			clusterScope.V(2).Info("Delete te desired subnet", "subnetName", subnetName)
-			return reconcile.Result{}, fmt.Errorf("%w Can not delete subnet for Osccluster %s/%s", err, clusterScope.GetNamespace(), clusterScope.GetName())
+			return reconcile.Result{}, fmt.Errorf("cannot delete subnet: %w", err)
 		}
 	}
 	return reconcile.Result{}, nil

--- a/controllers/osccluster_subnet_controller_unit_test.go
+++ b/controllers/osccluster_subnet_controller_unit_test.go
@@ -359,7 +359,7 @@ func TestReconcileSubnetCreate(t *testing.T) {
 			expCreateSubnetErr:    errors.New("CreateSubnet generic error"),
 			expGetSubnetIdsErr:    nil,
 			expReadTagErr:         nil,
-			expReconcileSubnetErr: errors.New("CreateSubnet generic error Can not create subnet for Osccluster test-system/test-osc"),
+			expReconcileSubnetErr: errors.New("cannot create subnet: CreateSubnet generic error"),
 		},
 		{
 			name:                  "user delete subnet without cluster-api",
@@ -397,12 +397,12 @@ func TestReconcileSubnetCreate(t *testing.T) {
 				if stc.expTagFound {
 					mockOscTagInterface.
 						EXPECT().
-						ReadTag(gomock.Eq("Name"), gomock.Eq(subnetName)).
+						ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(subnetName)).
 						Return(&tag, stc.expReadTagErr)
 				} else {
 					mockOscTagInterface.
 						EXPECT().
-						ReadTag(gomock.Eq("Name"), gomock.Eq(subnetName)).
+						ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(subnetName)).
 						Return(nil, stc.expReadTagErr)
 				}
 				subnetIds = append(subnetIds, subnetId)
@@ -418,24 +418,24 @@ func TestReconcileSubnetCreate(t *testing.T) {
 					subnetRef.ResourceMap[subnetName] = subnetId
 					mockOscSubnetInterface.
 						EXPECT().
-						CreateSubnet(gomock.Eq(subnetSpec), gomock.Eq(netId), gomock.Eq(clusterName), gomock.Eq(subnetName)).
+						CreateSubnet(gomock.Any(), gomock.Eq(subnetSpec), gomock.Eq(netId), gomock.Eq(clusterName), gomock.Eq(subnetName)).
 						Return(subnet.Subnet, stc.expCreateSubnetErr)
 				} else {
 					mockOscSubnetInterface.
 						EXPECT().
-						CreateSubnet(gomock.Eq(subnetSpec), gomock.Eq(netId), gomock.Eq(clusterName), gomock.Eq(subnetName)).
+						CreateSubnet(gomock.Any(), gomock.Eq(subnetSpec), gomock.Eq(netId), gomock.Eq(clusterName), gomock.Eq(subnetName)).
 						Return(nil, stc.expCreateSubnetErr)
 				}
 			}
 			if stc.expSubnetFound {
 				mockOscSubnetInterface.
 					EXPECT().
-					GetSubnetIdsFromNetIds(gomock.Eq(netId)).
+					GetSubnetIdsFromNetIds(gomock.Any(), gomock.Eq(netId)).
 					Return(subnetIds, stc.expGetSubnetIdsErr)
 			} else {
 				mockOscSubnetInterface.
 					EXPECT().
-					GetSubnetIdsFromNetIds(gomock.Eq(netId)).
+					GetSubnetIdsFromNetIds(gomock.Any(), gomock.Eq(netId)).
 					Return(nil, stc.expGetSubnetIdsErr)
 			}
 			reconcileSubnet, err := reconcileSubnet(ctx, clusterScope, mockOscSubnetInterface, mockOscTagInterface)
@@ -514,12 +514,12 @@ func TestReconcileSubnetGet(t *testing.T) {
 					if stc.expTagFound {
 						mockOscTagInterface.
 							EXPECT().
-							ReadTag(gomock.Eq("Name"), gomock.Eq(subnetName)).
+							ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(subnetName)).
 							Return(&tag, stc.expReadTagErr)
 					} else {
 						mockOscTagInterface.
 							EXPECT().
-							ReadTag(gomock.Eq("Name"), gomock.Eq(subnetName)).
+							ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(subnetName)).
 							Return(nil, stc.expReadTagErr)
 					}
 				}
@@ -528,12 +528,12 @@ func TestReconcileSubnetGet(t *testing.T) {
 			if stc.expSubnetFound {
 				mockOscSubnetInterface.
 					EXPECT().
-					GetSubnetIdsFromNetIds(gomock.Eq(netId)).
+					GetSubnetIdsFromNetIds(gomock.Any(), gomock.Eq(netId)).
 					Return(subnetIds, stc.expGetSubnetIdsErr)
 			} else {
 				mockOscSubnetInterface.
 					EXPECT().
-					GetSubnetIdsFromNetIds(gomock.Eq(netId)).
+					GetSubnetIdsFromNetIds(gomock.Any(), gomock.Eq(netId)).
 					Return(nil, stc.expGetSubnetIdsErr)
 			}
 			reconcileSubnet, err := reconcileSubnet(ctx, clusterScope, mockOscSubnetInterface, mockOscTagInterface)
@@ -574,7 +574,7 @@ func TestReconcileSubnetResourceId(t *testing.T) {
 			expNetFound:           true,
 			expReadTagErr:         errors.New("ReadTag generic error"),
 			expGetSubnetIdsErr:    nil,
-			expReconcileSubnetErr: errors.New("ReadTag generic error Can not get tag for OscCluster test-system/test-osc"),
+			expReconcileSubnetErr: errors.New("cannot get tag: ReadTag generic error"),
 		},
 	}
 	for _, stc := range subnetTestCases {
@@ -601,12 +601,12 @@ func TestReconcileSubnetResourceId(t *testing.T) {
 				if stc.expTagFound {
 					mockOscSubnetInterface.
 						EXPECT().
-						GetSubnetIdsFromNetIds(gomock.Eq(netId)).
+						GetSubnetIdsFromNetIds(gomock.Any(), gomock.Eq(netId)).
 						Return(subnetIds, stc.expGetSubnetIdsErr)
 
 					mockOscTagInterface.
 						EXPECT().
-						ReadTag(gomock.Eq("Name"), gomock.Eq(subnetName)).
+						ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(subnetName)).
 						Return(&tag, stc.expReadTagErr)
 				}
 			}
@@ -669,12 +669,12 @@ func TestReconcileDeleteSubnetGet(t *testing.T) {
 			if stc.expSubnetFound {
 				mockOscSubnetInterface.
 					EXPECT().
-					GetSubnetIdsFromNetIds(gomock.Eq(netId)).
+					GetSubnetIdsFromNetIds(gomock.Any(), gomock.Eq(netId)).
 					Return(subnetIds, stc.expGetSubnetIdsErr)
 			} else {
 				mockOscSubnetInterface.
 					EXPECT().
-					GetSubnetIdsFromNetIds(gomock.Eq(netId)).
+					GetSubnetIdsFromNetIds(gomock.Any(), gomock.Eq(netId)).
 					Return(nil, stc.expGetSubnetIdsErr)
 			}
 
@@ -721,11 +721,11 @@ func TestReconcileDeleteSubnetDeleteWithoutSpec(t *testing.T) {
 			subnetIds = append(subnetIds, subnetId)
 			mockOscSubnetInterface.
 				EXPECT().
-				GetSubnetIdsFromNetIds(gomock.Eq(netId)).
+				GetSubnetIdsFromNetIds(gomock.Any(), gomock.Eq(netId)).
 				Return(subnetIds, stc.expGetSubnetIdsErr)
 			mockOscSubnetInterface.
 				EXPECT().
-				DeleteSubnet(gomock.Eq(subnetId)).
+				DeleteSubnet(gomock.Any(), gomock.Eq(subnetId)).
 				Return(stc.expDeleteSubnetErr)
 			networkSpec := clusterScope.GetNetwork()
 			networkSpec.SetSubnetDefaultValue()
@@ -777,7 +777,7 @@ func TestReconcileDeleteSubnetDelete(t *testing.T) {
 			expNetFound:                 true,
 			expDeleteSubnetErr:          errors.New("DeleteSubnet generic error"),
 			expGetSubnetIdsErr:          nil,
-			expReconcileDeleteSubnetErr: errors.New("DeleteSubnet generic error Can not delete subnet for Osccluster test-system/test-osc"),
+			expReconcileDeleteSubnetErr: errors.New("cannot delete subnet: DeleteSubnet generic error"),
 		},
 	}
 	for _, stc := range subnetTestCases {
@@ -798,18 +798,18 @@ func TestReconcileDeleteSubnetDelete(t *testing.T) {
 				subnetIds = append(subnetIds, subnetId)
 				mockOscSubnetInterface.
 					EXPECT().
-					DeleteSubnet(gomock.Eq(subnetId)).
+					DeleteSubnet(gomock.Any(), gomock.Eq(subnetId)).
 					Return(stc.expDeleteSubnetErr)
 			}
 			if stc.expSubnetFound {
 				mockOscSubnetInterface.
 					EXPECT().
-					GetSubnetIdsFromNetIds(gomock.Eq(netId)).
+					GetSubnetIdsFromNetIds(gomock.Any(), gomock.Eq(netId)).
 					Return(subnetIds, stc.expGetSubnetIdsErr)
 			} else {
 				mockOscSubnetInterface.
 					EXPECT().
-					GetSubnetIdsFromNetIds(gomock.Eq(netId)).
+					GetSubnetIdsFromNetIds(gomock.Any(), gomock.Eq(netId)).
 					Return(nil, stc.expGetSubnetIdsErr)
 			}
 

--- a/controllers/oscmachine_controller.go
+++ b/controllers/oscmachine_controller.go
@@ -112,11 +112,11 @@ func (r *OscMachineReconciler) getTagSvc(ctx context.Context, scope scope.Cluste
 }
 
 func (r *OscMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
-	_ = log.FromContext(ctx)
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultedLoopTimeout(r.ReconcileTimeout))
 	defer cancel()
 
 	log := ctrl.LoggerFrom(ctx)
+	log.V(3).Info("Reconciling OscMachine")
 
 	oscMachine := &infrastructurev1beta1.OscMachine{}
 	if err := r.Get(ctx, req.NamespacedName, oscMachine); err != nil {
@@ -159,7 +159,6 @@ func (r *OscMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	clusterScope, err := scope.NewClusterScope(scope.ClusterScopeParams{
 		Client:     r.Client,
-		Logger:     log,
 		Cluster:    cluster,
 		OscCluster: oscCluster,
 	})
@@ -167,7 +166,6 @@ func (r *OscMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return reconcile.Result{}, err
 	}
 	machineScope, err := scope.NewMachineScope(scope.MachineScopeParams{
-		Logger:     log,
 		Client:     r.Client,
 		Cluster:    cluster,
 		Machine:    machine,
@@ -190,30 +188,29 @@ func (r *OscMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 // reconcile reconcile the creation of the machine
 func (r *OscMachineReconciler) reconcile(ctx context.Context, machineScope *scope.MachineScope, clusterScope *scope.ClusterScope) (reconcile.Result, error) {
-	machineScope.V(2).Info("Reconciling OscMachine")
+	log := ctrl.LoggerFrom(ctx)
 	oscmachine := machineScope.OscMachine
 	if oscmachine.Status.FailureReason != nil || oscmachine.Status.FailureMessage != nil {
-		machineScope.V(2).Info("Error state detected, skipping reconciliation")
+		log.V(3).Info("Error state detected, skipping reconciliation")
 		return reconcile.Result{}, nil
 	}
 
 	controllerutil.AddFinalizer(oscmachine, "oscmachine.infrastructure.cluster.x-k8s.io")
 
 	if !machineScope.Cluster.Status.InfrastructureReady {
-		machineScope.V(2).Info("Cluster infrastructure is not ready yet")
+		log.V(3).Info("Cluster infrastructure is not ready yet")
 		conditions.MarkFalse(oscmachine, infrastructurev1beta1.VmReadyCondition, infrastructurev1beta1.WaitingForClusterInfrastructureReason, clusterv1.ConditionSeverityInfo, "")
 		return ctrl.Result{}, nil
 	}
-	machineScope.V(2).Info("Check bootstrap data")
 	if machineScope.Machine.Spec.Bootstrap.DataSecretName == nil {
-		machineScope.V(2).Info("Bootstrap data secret reference is not yet availablle")
+		log.V(3).Info("Bootstrap data secret reference is not yet availablle")
 		return ctrl.Result{}, nil
 	}
 	if len(machineScope.OscMachine.Spec.Node.Volumes) > 0 {
-		machineScope.V(2).Info("Find volumes")
+		log.V(2).Info("Find volumes")
 		volumeName, err := checkVolumeFormatParameters(machineScope)
 		if err != nil {
-			return reconcile.Result{}, fmt.Errorf("%w Can not create volume %s for OscMachine %s/%s", err, volumeName, machineScope.GetNamespace(), machineScope.GetName())
+			return reconcile.Result{}, fmt.Errorf("cannot create volume %s: %w", volumeName, err)
 		}
 	}
 
@@ -221,16 +218,15 @@ func (r *OscMachineReconciler) reconcile(ctx context.Context, machineScope *scop
 
 	vmName, err := checkVmFormatParameters(machineScope, clusterScope)
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("%w Can not create vm %s for OscMachine %s/%s", err, vmName, machineScope.GetNamespace(), machineScope.GetName())
+		return reconcile.Result{}, fmt.Errorf("cannot create vm %s: %w", vmName, err)
 	}
 
 	keypairName, err := checkKeypairFormatParameters(machineScope)
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("%w Can not create vm %s for OscMachine %s/%s", err, keypairName, machineScope.GetNamespace(), machineScope.GetName())
+		return reconcile.Result{}, fmt.Errorf("cannot create vm %s: %w", keypairName, err)
 	}
 
 	if len(machineScope.OscMachine.Spec.Node.Volumes) > 0 {
-		machineScope.V(2).Info("Find Volumes")
 		duplicateResourceVolumeErr := checkVolumeOscDuplicateName(machineScope)
 		if duplicateResourceVolumeErr != nil {
 			return reconcile.Result{}, duplicateResourceVolumeErr
@@ -242,7 +238,6 @@ func (r *OscMachineReconciler) reconcile(ctx context.Context, machineScope *scop
 		return reconcile.Result{}, duplicateResourceVmPrivateIpErr
 	}
 	if len(machineScope.OscMachine.Spec.Node.Volumes) > 0 {
-		machineScope.V(2).Info("Find volumes")
 		checkOscAssociateVmVolumeErr := checkVmVolumeOscAssociateResourceName(machineScope)
 		if checkOscAssociateVmVolumeErr != nil {
 			return reconcile.Result{}, checkOscAssociateVmVolumeErr
@@ -289,17 +284,16 @@ func (r *OscMachineReconciler) reconcile(ctx context.Context, machineScope *scop
 	imageSvc := r.getImageSvc(ctx, *clusterScope)
 	reconcileImage, err := reconcileImage(ctx, machineScope, imageSvc)
 	if err != nil {
-		machineScope.Error(err, "failed to reconcile Image")
+		log.V(2).Error(err, "failed to reconcile Image")
 		return reconcileImage, err
 	}
 
 	volumeSvc := r.getVolumeSvc(ctx, *clusterScope)
 	tagSvc := r.getTagSvc(ctx, *clusterScope)
 	if len(machineScope.OscMachine.Spec.Node.Volumes) > 0 {
-		machineScope.V(2).Info("Find Volumes")
 		reconcileVolume, err := reconcileVolume(ctx, machineScope, volumeSvc, tagSvc)
 		if err != nil {
-			machineScope.Error(err, "failed to reconcile volume")
+			log.V(2).Error(err, "failed to reconcile volume")
 			conditions.MarkFalse(oscmachine, infrastructurev1beta1.VolumeReadyCondition, infrastructurev1beta1.VolumeReconciliationFailedReason, clusterv1.ConditionSeverityWarning, "%s", err.Error())
 			return reconcileVolume, err
 		}
@@ -309,7 +303,7 @@ func (r *OscMachineReconciler) reconcile(ctx context.Context, machineScope *scop
 	keypairSvc := r.getKeyPairSvc(ctx, *clusterScope)
 	reconcileKeypair, err := reconcileKeypair(ctx, machineScope, keypairSvc)
 	if err != nil {
-		machineScope.Error(err, "failed to reconcile keypair")
+		log.V(2).Error(err, "failed to reconcile keypair")
 		return reconcileKeypair, err
 	}
 
@@ -318,10 +312,9 @@ func (r *OscMachineReconciler) reconcile(ctx context.Context, machineScope *scop
 	loadBalancerSvc := r.getLoadBalancerSvc(ctx, *clusterScope)
 	securityGroupSvc := r.getSecurityGroupSvc(ctx, *clusterScope)
 
-	machineScope.V(4).Info("Reconciling Vm")
 	reconcileVm, err := reconcileVm(ctx, clusterScope, machineScope, vmSvc, volumeSvc, publicIpSvc, loadBalancerSvc, securityGroupSvc, tagSvc)
 	if err != nil {
-		machineScope.Error(err, "failed to reconcile vm")
+		log.V(2).Error(err, "failed to reconcile vm")
 		conditions.MarkFalse(oscmachine, infrastructurev1beta1.VmReadyCondition, infrastructurev1beta1.VmNotReadyReason, clusterv1.ConditionSeverityWarning, "%s", err.Error())
 		return reconcileVm, err
 	}
@@ -330,23 +323,23 @@ func (r *OscMachineReconciler) reconcile(ctx context.Context, machineScope *scop
 	switch *vmState {
 	case infrastructurev1beta1.VmStatePending:
 		machineScope.SetNotReady()
-		machineScope.V(4).Info("Vm pending", "state", vmState)
+		log.V(4).Info("Vm pending", "state", vmState)
 		conditions.MarkFalse(oscmachine, infrastructurev1beta1.VmReadyCondition, infrastructurev1beta1.VmNotReadyReason, clusterv1.ConditionSeverityWarning, "")
 	case infrastructurev1beta1.VmStateStopping, infrastructurev1beta1.VmStateStopped:
 		machineScope.SetNotReady()
-		machineScope.V(4).Info("Vm stopped", "state", vmState)
+		log.V(4).Info("Vm stopped", "state", vmState)
 		conditions.MarkFalse(oscmachine, infrastructurev1beta1.VmReadyCondition, infrastructurev1beta1.VmStoppedReason, clusterv1.ConditionSeverityWarning, "")
 	case infrastructurev1beta1.VmStateRunning:
 		machineScope.SetReady()
-		machineScope.V(4).Info("Vm running", "state", vmState)
+		log.V(4).Info("Vm running", "state", vmState)
 		conditions.MarkTrue(oscmachine, infrastructurev1beta1.VmReadyCondition)
 	case infrastructurev1beta1.VmStateShuttingDown, infrastructurev1beta1.VmStateTerminated:
 		machineScope.SetNotReady()
-		machineScope.V(4).Info("Unexpected vm termination", "state", vmState)
+		log.V(4).Info("Unexpected vm termination", "state", vmState)
 		conditions.MarkFalse(oscmachine, infrastructurev1beta1.VmReadyCondition, infrastructurev1beta1.VmTerminatedReason, clusterv1.ConditionSeverityError, "")
 	default:
 		machineScope.SetNotReady()
-		machineScope.V(4).Info("Vm state is undefined", "state", vmState)
+		log.V(4).Info("Vm state is undefined", "state", vmState)
 		machineScope.SetFailureReason(capierrors.UpdateMachineError)
 		machineScope.SetFailureMessage(fmt.Errorf("instance state %+v  is undefined", vmState))
 		conditions.MarkUnknown(oscmachine, infrastructurev1beta1.VmReadyCondition, "", "")
@@ -356,10 +349,10 @@ func (r *OscMachineReconciler) reconcile(ctx context.Context, machineScope *scop
 
 // reconcileDelete reconcile the deletion of the machine
 func (r *OscMachineReconciler) reconcileDelete(ctx context.Context, machineScope *scope.MachineScope, clusterScope *scope.ClusterScope) (reconcile.Result, error) {
-	machineScope.V(2).Info("Reconciling delete OscMachine")
+	log := ctrl.LoggerFrom(ctx)
+	log.V(3).Info("Reconciling delete OscMachine")
 	oscmachine := machineScope.OscMachine
 	if len(machineScope.OscMachine.Spec.Node.Volumes) > 0 {
-		machineScope.V(2).Info("Find volumes")
 		volumeSvc := r.getVolumeSvc(ctx, *clusterScope)
 		reconcileDeleteVolume, err := reconcileDeleteVolume(ctx, machineScope, volumeSvc)
 		if err != nil {
@@ -421,10 +414,10 @@ func (r *OscMachineReconciler) OscClusterToOscMachines(ctx context.Context) hand
 
 		c, ok := o.(*infrastructurev1beta1.OscCluster)
 		if !ok {
-			log.Error(fmt.Errorf("expected a OscCluster but got a %T", o), "failed to get OscMachine for OscCluster")
+			log.V(1).Error(fmt.Errorf("expected a OscCluster but got a %T", o), "failed to get OscMachine for OscCluster")
 			return nil
 		}
-		log = log.WithValues("objectMapper", "oscClusterToOscMachine", "namespace", c.Namespace, "oscCluster", c.Name)
+		log = log.WithValues("objectMapper", "oscClusterToOscMachine", "namespace", c.Namespace)
 
 		if !c.ObjectMeta.DeletionTimestamp.IsZero() {
 			log.V(1).Info("OscCluster has a deletion timestamp, skipping mapping.")
@@ -437,14 +430,14 @@ func (r *OscMachineReconciler) OscClusterToOscMachines(ctx context.Context) hand
 			log.V(1).Info("Cluster for OscCluster not found, skipping mapping.")
 			return result
 		case err != nil:
-			log.Error(err, "failed to get owning cluster, skipping mapping.")
+			log.V(1).Error(err, "failed to get owning cluster, skipping mapping.")
 			return result
 		}
 
 		labels := map[string]string{"cluster.x-k8s.io/cluster-name": cluster.Name}
 		machineList := &clusterv1.MachineList{}
 		if err := r.List(ctx, machineList, client.InNamespace(c.Namespace), client.MatchingLabels(labels)); err != nil {
-			log.Error(err, "failed to list Machines, skipping mapping.")
+			log.V(1).Error(err, "failed to list Machines, skipping mapping.")
 			return nil
 		}
 		for _, m := range machineList.Items {

--- a/controllers/oscmachine_image_controller_unit_test.go
+++ b/controllers/oscmachine_image_controller_unit_test.go
@@ -249,7 +249,7 @@ func TestReconcileImageGet(t *testing.T) {
 			expGetImageIdErr:     nil,
 			expGetImageNameErr:   nil,
 			expGetImageErr:       errors.New("GetImage generic error"),
-			expReconcileImageErr: errors.New("GetImage generic error"),
+			expReconcileImageErr: errors.New("cannot get image: GetImage generic error"),
 			expImageErr:          true,
 		},
 		{
@@ -290,7 +290,7 @@ func TestReconcileImageGet(t *testing.T) {
 			expGetImageIdErr:     nil,
 			expGetImageNameErr:   errors.New("GetImageName generic error"),
 			expGetImageErr:       nil,
-			expReconcileImageErr: errors.New("GetImageName generic error"),
+			expReconcileImageErr: errors.New("cannot get image: GetImageName generic error"),
 			expImageErr:          false,
 		},
 		{
@@ -308,7 +308,7 @@ func TestReconcileImageGet(t *testing.T) {
 			expGetImageIdErr:     nil,
 			expGetImageNameErr:   nil,
 			expGetImageErr:       errors.New("GetImage generic error"),
-			expReconcileImageErr: errors.New("GetImage generic error"),
+			expReconcileImageErr: errors.New("cannot get image: GetImage generic error"),
 			expImageErr:          false,
 		},
 		{
@@ -330,7 +330,7 @@ func TestReconcileImageGet(t *testing.T) {
 			expGetImageIdErr:     errors.New("GetImageId generic error"),
 			expGetImageNameErr:   nil,
 			expGetImageErr:       nil,
-			expReconcileImageErr: errors.New("GetImageId generic error"),
+			expReconcileImageErr: errors.New("cannot get image: GetImageId generic error"),
 		},
 	}
 	for _, itc := range imageTestCases {
@@ -355,24 +355,24 @@ func TestReconcileImageGet(t *testing.T) {
 			if itc.expImageNameFound {
 				mockOscimageInterface.
 					EXPECT().
-					GetImageId(gomock.Eq(imageName)).
+					GetImageId(gomock.Any(), gomock.Eq(imageName)).
 					Return(imageId, itc.expGetImageIdErr)
 			} else {
 				mockOscimageInterface.
 					EXPECT().
-					GetImageName(gomock.Eq(imageId)).
+					GetImageName(gomock.Any(), gomock.Eq(imageId)).
 					Return(imageName, itc.expGetImageNameErr)
 			}
 			if itc.expImageFound {
 				if itc.expImageErr {
 					mockOscimageInterface.
 						EXPECT().
-						GetImage(gomock.Eq(imageId)).
+						GetImage(gomock.Any(), gomock.Eq(imageId)).
 						Return(nil, itc.expGetImageErr)
 				} else {
 					mockOscimageInterface.
 						EXPECT().
-						GetImage(gomock.Eq(imageId)).
+						GetImage(gomock.Any(), gomock.Eq(imageId)).
 						Return(&(*image.Images)[0], itc.expGetImageErr)
 				}
 			}

--- a/controllers/oscmachine_vm_controller_unit_test.go
+++ b/controllers/oscmachine_vm_controller_unit_test.go
@@ -2860,12 +2860,12 @@ func TestReconcileVmGet(t *testing.T) {
 			if vtc.expGetVmFound {
 				mockOscVmInterface.
 					EXPECT().
-					GetVm(gomock.Eq(vmId)).
+					GetVm(gomock.Any(), gomock.Eq(vmId)).
 					Return(vm, vtc.expGetVmErr)
 			} else {
 				mockOscVmInterface.
 					EXPECT().
-					GetVm(gomock.Eq(vmId)).
+					GetVm(gomock.Any(), gomock.Eq(vmId)).
 					Return(nil, vtc.expGetVmErr)
 			}
 
@@ -3001,7 +3001,7 @@ func TestReconcileDeleteVm(t *testing.T) {
 			expDeleteInboundSecurityGroupRuleErr:    nil,
 			expDeleteOutboundSecurityGroupRuleErr:   nil,
 			expCheckUnlinkPublicIpErr:               nil,
-			expReconcileDeleteVmErr:                 errors.New("DeleteVm generic error Can not delete vm for OscMachine test-system/test-osc"),
+			expReconcileDeleteVmErr:                 errors.New("cannot delete vm: DeleteVm generic error"),
 		},
 	}
 	for _, vtc := range vmTestCases {
@@ -3064,12 +3064,12 @@ func TestReconcileDeleteVm(t *testing.T) {
 			if vtc.expGetVmFound {
 				mockOscVmInterface.
 					EXPECT().
-					GetVm(gomock.Eq(vmId)).
+					GetVm(gomock.Any(), gomock.Eq(vmId)).
 					Return(vm, vtc.expGetVmErr)
 			} else {
 				mockOscVmInterface.
 					EXPECT().
-					GetVm(gomock.Eq(vmId)).
+					GetVm(gomock.Any(), gomock.Eq(vmId)).
 					Return(nil, vtc.expGetVmErr)
 			}
 
@@ -3099,37 +3099,37 @@ func TestReconcileDeleteVm(t *testing.T) {
 			}
 			mockOscPublicIpInterface.
 				EXPECT().
-				UnlinkPublicIp(gomock.Eq(linkPublicIpId)).
+				UnlinkPublicIp(gomock.Any(), gomock.Eq(linkPublicIpId)).
 				Return(vtc.expCheckUnlinkPublicIpErr)
 			vmIds := []string{vmId}
 			mockOscLoadBalancerInterface.
 				EXPECT().
-				UnlinkLoadBalancerBackendMachines(gomock.Eq(vmIds), gomock.Eq(loadBalancerName)).
+				UnlinkLoadBalancerBackendMachines(gomock.Any(), gomock.Eq(vmIds), gomock.Eq(loadBalancerName)).
 				Return(vtc.expUnlinkLoadBalancerBackendMachineErr)
 
 			if vtc.expDeleteOutboundSecurityGroupRuleFound {
 				mockOscSecurityGroupInterface.
 					EXPECT().
-					DeleteSecurityGroupRule(gomock.Eq(associateSecurityGroupId), gomock.Eq("Outbound"), gomock.Eq(ipProtocol), "", gomock.Eq(securityGroupIds[0]), gomock.Eq(fromPortRange), gomock.Eq(toPortRange)).
+					DeleteSecurityGroupRule(gomock.Any(), gomock.Eq(associateSecurityGroupId), gomock.Eq("Outbound"), gomock.Eq(ipProtocol), "", gomock.Eq(securityGroupIds[0]), gomock.Eq(fromPortRange), gomock.Eq(toPortRange)).
 					Return(vtc.expDeleteOutboundSecurityGroupRuleErr)
 			}
 			if vtc.expDeleteDedicatedPublicIpFound {
 				mockOscPublicIpInterface.
 					EXPECT().
-					DeletePublicIp(gomock.Eq("eipassoc-test-osc-publicIp-uid")).
+					DeletePublicIp(gomock.Any(), gomock.Eq("eipassoc-test-osc-publicIp-uid")).
 					Return(nil)
 			}
 
 			if vtc.expDeleteInboundSecurityGroupRuleFound {
 				mockOscSecurityGroupInterface.
 					EXPECT().
-					DeleteSecurityGroupRule(gomock.Eq(associateSecurityGroupId), gomock.Eq("Inbound"), gomock.Eq(ipProtocol), "", gomock.Eq(securityGroupIds[0]), gomock.Eq(fromPortRange), gomock.Eq(toPortRange)).
+					DeleteSecurityGroupRule(gomock.Any(), gomock.Eq(associateSecurityGroupId), gomock.Eq("Inbound"), gomock.Eq(ipProtocol), "", gomock.Eq(securityGroupIds[0]), gomock.Eq(fromPortRange), gomock.Eq(toPortRange)).
 					Return(vtc.expDeleteInboundSecurityGroupRuleErr)
 			}
 
 			mockOscVmInterface.
 				EXPECT().
-				DeleteVm(gomock.Eq(vmId)).
+				DeleteVm(gomock.Any(), gomock.Eq(vmId)).
 				Return(vtc.expDeleteVmErr)
 
 			reconcileDeleteVm, err := reconcileDeleteVm(ctx, clusterScope, machineScope, mockOscVmInterface, mockOscPublicIpInterface, mockOscLoadBalancerInterface, mockOscSecurityGroupInterface)
@@ -3164,7 +3164,7 @@ func TestReconcileDeleteVmUnlinkPublicIp(t *testing.T) {
 			expGetVmErr:                 nil,
 			expCheckUnlinkPublicIpFound: true,
 			expCheckUnlinkPublicIpErr:   errors.New("CheckUnlinkPublicIp generic error"),
-			expReconcileDeleteVmErr:     errors.New("CheckUnlinkPublicIp generic error Can not unlink publicIp for OscCluster test-system/test-osc"),
+			expReconcileDeleteVmErr:     errors.New("cannot unlink publicIp: CheckUnlinkPublicIp generic error"),
 		},
 	}
 	for _, vtc := range vmTestCases {
@@ -3207,19 +3207,19 @@ func TestReconcileDeleteVmUnlinkPublicIp(t *testing.T) {
 			if vtc.expGetVmFound {
 				mockOscVmInterface.
 					EXPECT().
-					GetVm(gomock.Eq(vmId)).
+					GetVm(gomock.Any(), gomock.Eq(vmId)).
 					Return(vm, vtc.expGetVmErr)
 			} else {
 				mockOscVmInterface.
 					EXPECT().
-					GetVm(gomock.Eq(vmId)).
+					GetVm(gomock.Any(), gomock.Eq(vmId)).
 					Return(nil, vtc.expGetVmErr)
 			}
 
 			if vtc.expCheckUnlinkPublicIpFound {
 				mockOscPublicIpInterface.
 					EXPECT().
-					UnlinkPublicIp(gomock.Eq(linkPublicIpId)).
+					UnlinkPublicIp(gomock.Any(), gomock.Eq(linkPublicIpId)).
 					Return(vtc.expCheckUnlinkPublicIpErr)
 			}
 
@@ -3288,12 +3288,12 @@ func TestReconcileDeleteVmResourceId(t *testing.T) {
 			if vtc.expGetVmFound {
 				mockOscVmInterface.
 					EXPECT().
-					GetVm(gomock.Eq(vmId)).
+					GetVm(gomock.Any(), gomock.Eq(vmId)).
 					Return(vm, vtc.expGetVmErr)
 			} else {
 				mockOscVmInterface.
 					EXPECT().
-					GetVm(gomock.Eq(vmId)).
+					GetVm(gomock.Any(), gomock.Eq(vmId)).
 					Return(nil, vtc.expGetVmErr)
 			}
 
@@ -3436,17 +3436,17 @@ func TestReconcileDeleteVmWithoutSpec(t *testing.T) {
 				}
 				mockOscVmInterface.
 					EXPECT().
-					GetVm(gomock.Eq(vmId)).
+					GetVm(gomock.Any(), gomock.Eq(vmId)).
 					Return(vm, vtc.expGetVmErr)
 			} else {
 				mockOscVmInterface.
 					EXPECT().
-					GetVm(gomock.Eq(vmId)).
+					GetVm(gomock.Any(), gomock.Eq(vmId)).
 					Return(nil, vtc.expGetVmErr)
 			}
 			mockOscVmInterface.
 				EXPECT().
-				DeleteVm(gomock.Eq(vmId)).
+				DeleteVm(gomock.Any(), gomock.Eq(vmId)).
 				Return(vtc.expDeleteVmErr)
 			reconcileDeleteVm, err := reconcileDeleteVm(ctx, clusterScope, machineScope, mockOscVmInterface, mockOscPublicIpInterface, mockOscLoadBalancerInterface, mockOscSecurityGroupInterface)
 			if vtc.expReconcileDeleteVmErr != nil {
@@ -3485,14 +3485,14 @@ func TestReconcileDeleteVmSecurityGroup(t *testing.T) {
 			expDeleteInboundSecurityGroupRuleFound:  true,
 			expDeleteOutboundSecurityGroupRuleFound: true,
 			expUnlinkLoadBalancerBackendMachineErr:  nil,
-			expDeleteInboundSecurityGroupRuleErr:    errors.New("CreateSecurityGroupRule generic error"),
+			expDeleteInboundSecurityGroupRuleErr:    errors.New("DeleteSecurityGroupRule generic error"),
 			expDeleteOutboundSecurityGroupRuleErr:   nil,
 			expSecurityGroupRuleFound:               true,
 			expDeleteVmErr:                          nil,
 			expGetVmFound:                           true,
 			expGetVmErr:                             nil,
 			expCheckUnlinkPublicIpErr:               nil,
-			expReconcileDeleteVmErr:                 errors.New("CreateSecurityGroupRule generic error Can not delete inbound securityGroupRule for OscCluster test-system/test-osc"),
+			expReconcileDeleteVmErr:                 errors.New("cannot delete inbound securityGroupRule: DeleteSecurityGroupRule generic error"),
 		},
 		{
 			name:                                    "failed to delete outbound securitygroup",
@@ -3506,9 +3506,9 @@ func TestReconcileDeleteVmSecurityGroup(t *testing.T) {
 			expGetVmFound:                           true,
 			expGetVmErr:                             nil,
 			expDeleteInboundSecurityGroupRuleErr:    nil,
-			expDeleteOutboundSecurityGroupRuleErr:   errors.New("CreateSecurityGroupRule generic error"),
+			expDeleteOutboundSecurityGroupRuleErr:   errors.New("DeleteSecurityGroupRule generic error"),
 			expCheckUnlinkPublicIpErr:               nil,
-			expReconcileDeleteVmErr:                 errors.New("CreateSecurityGroupRule generic error Can not delete outbound securityGroupRule for OscCluster test-system/test-osc"),
+			expReconcileDeleteVmErr:                 errors.New("cannot delete outbound securityGroupRule: DeleteSecurityGroupRule generic error"),
 		},
 	}
 	for _, vtc := range vmTestCases {
@@ -3563,36 +3563,36 @@ func TestReconcileDeleteVmSecurityGroup(t *testing.T) {
 			if vtc.expGetVmFound {
 				mockOscVmInterface.
 					EXPECT().
-					GetVm(gomock.Eq(vmId)).
+					GetVm(gomock.Any(), gomock.Eq(vmId)).
 					Return(vm, vtc.expGetVmErr)
 			} else {
 				mockOscVmInterface.
 					EXPECT().
-					GetVm(gomock.Eq(vmId)).
+					GetVm(gomock.Any(), gomock.Eq(vmId)).
 					Return(nil, vtc.expGetVmErr)
 			}
 
 			mockOscPublicIpInterface.
 				EXPECT().
-				UnlinkPublicIp(gomock.Eq(linkPublicIpId)).
+				UnlinkPublicIp(gomock.Any(), gomock.Eq(linkPublicIpId)).
 				Return(vtc.expCheckUnlinkPublicIpErr)
 			vmIds := []string{vmId}
 			mockOscLoadBalancerInterface.
 				EXPECT().
-				UnlinkLoadBalancerBackendMachines(gomock.Eq(vmIds), gomock.Eq(loadBalancerName)).
+				UnlinkLoadBalancerBackendMachines(gomock.Any(), gomock.Eq(vmIds), gomock.Eq(loadBalancerName)).
 				Return(vtc.expUnlinkLoadBalancerBackendMachineErr)
 
 			if vtc.expDeleteOutboundSecurityGroupRuleFound {
 				mockOscSecurityGroupInterface.
 					EXPECT().
-					DeleteSecurityGroupRule(gomock.Eq(associateSecurityGroupId), gomock.Eq("Outbound"), gomock.Eq(ipProtocol), "", gomock.Eq(securityGroupIds[0]), gomock.Eq(fromPortRange), gomock.Eq(toPortRange)).
+					DeleteSecurityGroupRule(gomock.Any(), gomock.Eq(associateSecurityGroupId), gomock.Eq("Outbound"), gomock.Eq(ipProtocol), "", gomock.Eq(securityGroupIds[0]), gomock.Eq(fromPortRange), gomock.Eq(toPortRange)).
 					Return(vtc.expDeleteOutboundSecurityGroupRuleErr)
 			}
 
 			if vtc.expDeleteInboundSecurityGroupRuleFound {
 				mockOscSecurityGroupInterface.
 					EXPECT().
-					DeleteSecurityGroupRule(gomock.Eq(associateSecurityGroupId), gomock.Eq("Inbound"), gomock.Eq(ipProtocol), "", gomock.Eq(securityGroupIds[0]), gomock.Eq(fromPortRange), gomock.Eq(toPortRange)).
+					DeleteSecurityGroupRule(gomock.Any(), gomock.Eq(associateSecurityGroupId), gomock.Eq("Inbound"), gomock.Eq(ipProtocol), "", gomock.Eq(securityGroupIds[0]), gomock.Eq(fromPortRange), gomock.Eq(toPortRange)).
 					Return(vtc.expDeleteInboundSecurityGroupRuleErr)
 			}
 

--- a/controllers/oscmachinetemplate_capacity_controller.go
+++ b/controllers/oscmachinetemplate_capacity_controller.go
@@ -21,138 +21,80 @@ import (
 	"fmt"
 	"time"
 
-	infrastructurev1beta1 "github.com/outscale/cluster-api-provider-outscale/api/v1beta1"
 	"github.com/outscale/cluster-api-provider-outscale/cloud/scope"
 	"github.com/outscale/cluster-api-provider-outscale/cloud/services/compute"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/client-go/tools/record"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	"sigs.k8s.io/cluster-api/util/predicates"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-// getVmSvc retrieve vmSvc
-func (r *OscMachineTemplateReconciler) getVmSvc(ctx context.Context, scope scope.ClusterScope) compute.OscVmInterface {
-	return compute.NewService(ctx, &scope)
-}
-
-type OscMachineTemplateReconciler struct {
-	client.Client
-	Recorder         record.EventRecorder
-	ReconcileTimeout time.Duration
-	WatchFilterValue string
-}
-
-// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=oscmachinetemplates,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=oscmachinetemplates/status,verbs=get;update;patch
-
-// Reconcile manages the lifecycle of an OscMachineTemplate object.
-func (r *OscMachineTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
-	log := ctrl.LoggerFrom(ctx).WithValues("oscmachinetemplate", req.NamespacedName)
-	log.V(2).Info("Reconcile OscMachineTemplate")
-
-	machineTemplate := &infrastructurev1beta1.OscMachineTemplate{}
-	if err := r.Get(ctx, req.NamespacedName, machineTemplate); err != nil {
-		if apierrors.IsNotFound(err) {
-			return reconcile.Result{}, nil
+// reconcileCapacity reconcile oscmachinetemplate capacity
+func reconcileCapacity(ctx context.Context, clusterScope *scope.ClusterScope, machineTemplateScope *scope.MachineTemplateScope, vmSvc compute.OscVmInterface) (reconcile.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+	var machineSize int
+	var machineKcpCount int32
+	var machineKwCount int32
+	var machineKcpReady int32
+	var machineKwReady int32
+	var machines []*clusterv1.Machine
+	var err error
+	vmReplica := machineTemplateScope.GetReplica()
+	if vmReplica != 1 {
+		machines, _, err = clusterScope.ListMachines(ctx)
+		if err != nil {
+			return reconcile.Result{}, fmt.Errorf("cannot get ListMachine: %w", err)
 		}
-		return reconcile.Result{}, err
-	}
-
-	machineTemplateScope, err := scope.NewMachineTemplateScope(scope.MachineTemplateScopeParams{
-		Client:             r.Client,
-		Logger:             log,
-		OscMachineTemplate: machineTemplate,
-	})
-
-	if err != nil {
-		log.V(2).Info("Cluster is not available yet")
-		log.Error(err, "failed to get machineTemplate.")
-		return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
-	}
-	clusterName := machineTemplateScope.GetClusterName()
-
-	labels := map[string]string{"ccm": clusterName + "-crs-ccm"}
-	clusterList := &clusterv1.ClusterList{}
-	cluster := clusterv1.Cluster{}
-	err = r.List(ctx, clusterList, client.InNamespace(machineTemplate.Namespace), client.MatchingLabels(labels))
-	if err != nil {
-		log.V(2).Info("Cluster is not available yet")
-		log.Error(err, "failed to get owning cluster.")
-		return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+		machineSize = len(machines)
+		log.V(4).Info("Get OscMachine Size", "machineSize", machineSize)
 	} else {
-		for _, cluster = range clusterList.Items {
-			machineTemplateScope.V(4).Info("Get Cluster", "cluster", cluster.Name)
-			log.V(2).Info("Find cluster")
-		}
-		if len(clusterList.Items) == 0 {
-			log.V(2).Info("OscCluster is not available yet")
-			return reconcile.Result{RequeueAfter: 60 * time.Second}, nil
-		}
+		log.V(3).Info("Do not wait for OscMachine")
+		machineSize = 1
+		machineKcpReady = 1
+		machineKcpCount = 1
 	}
-	oscCluster := &infrastructurev1beta1.OscCluster{}
-	oscClusterName := client.ObjectKey{
-		Namespace: machineTemplate.Namespace,
-		Name:      cluster.Spec.InfrastructureRef.Name,
+
+	if machineSize > 0 {
+		if vmReplica != 1 {
+			names := make([]string, len(machines))
+			for i, m := range machines {
+				names[i] = "machine/" + m.Name
+				machineLabel := m.Labels
+				for labelKey := range machineLabel {
+					switch labelKey {
+					case "cluster.x-k8s.io/control-plane":
+						log.V(4).Info("Control plane", "machineKcp", m.Name)
+						machineKcpCount++
+						if m.Status.Phase == "Running" || m.Status.Phase == "Provisioned" {
+							machineKcpReady++
+						}
+					case "cluster.x-k8s.io/deployment-name":
+						log.V(4).Info("Worker", "machineKw", m.Name)
+						machineKwCount++
+						if m.Status.Phase == "Running" || m.Status.Phase == "Provisioned" {
+							machineKwReady++
+						}
+					}
+				}
+			}
+		}
+		role := machineTemplateScope.GetRole()
+		if role == "controlplane" && machineKcpReady > 0 && machineKcpCount > 0 {
+			log.V(3).Info("At least one controlplane node ready")
+		} else if role == "" && machineKwReady > 0 && machineKwCount > 0 {
+			log.V(3).Info("At least one worker node ready")
+		} else {
+			log.V(3).Info("Node is not ready yet")
+			return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+		}
+	} else {
+		return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
 	}
-	if err := r.Client.Get(ctx, oscClusterName, oscCluster); err != nil {
-		log.Info("OscCluster is not available yet")
+	clusterName := machineTemplateScope.GetClusterName() + "-" + clusterScope.GetUID()
+	vmType := machineTemplateScope.GetVmType()
+	capacity, err := vmSvc.GetCapacity(ctx, "OscK8sClusterID/"+clusterName, "owned", vmType)
+	if err != nil {
 		return reconcile.Result{}, err
 	}
-	clusterScope, err := scope.NewClusterScope(scope.ClusterScopeParams{
-		Client:     r.Client,
-		Logger:     log,
-		Cluster:    &cluster,
-		OscCluster: oscCluster,
-	})
-	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to create scope: %w", err)
-	}
-	defer func() {
-		if err := machineTemplateScope.Close(); err != nil && reterr == nil {
-			reterr = err
-		}
-	}()
-	if !machineTemplate.ObjectMeta.DeletionTimestamp.IsZero() {
-		return r.reconcileDelete(ctx, machineTemplateScope, clusterScope)
-	}
-	return r.reconcile(ctx, machineTemplateScope, clusterScope)
-}
-
-// reconcile reconcile the creation of the machine
-func (r *OscMachineTemplateReconciler) reconcile(ctx context.Context, machineTemplateScope *scope.MachineTemplateScope, clusterScope *scope.ClusterScope) (reconcile.Result, error) {
-	machineTemplateScope.V(2).Info("Reconciling OscMachineTemplate")
-	controllerutil.AddFinalizer(machineTemplateScope.OscMachineTemplate, "oscmachine.infrastructure.cluster.x-k8s.io")
-
-	if err := machineTemplateScope.PatchObject(); err != nil {
-		return reconcile.Result{}, err
-	}
-
-	vmSvc := r.getVmSvc(ctx, *clusterScope)
-	reconcileCapacity, err := reconcileCapacity(ctx, clusterScope, machineTemplateScope, vmSvc)
-	if err != nil {
-		return reconcileCapacity, err
-	}
-	return reconcileCapacity, nil
-}
-
-// reconcileDelete reconcile the deletion of the machine
-func (r *OscMachineTemplateReconciler) reconcileDelete(ctx context.Context, machineTemplateScope *scope.MachineTemplateScope, clusterScope *scope.ClusterScope) (reconcile.Result, error) {
-	machineTemplateScope.V(2).Info("Reconciling delete OscMachineTemplate")
-	oscmachinetemplate := machineTemplateScope.OscMachineTemplate
-	controllerutil.RemoveFinalizer(oscmachinetemplate, "oscmachinetemplate.infrastructure.cluster.x-k8s.io")
+	machineTemplateScope.SetCapacity(capacity)
 	return reconcile.Result{}, nil
-}
-
-// SetupWithManager sets up the controller with the Manager.
-func (r *OscMachineTemplateReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		WithOptions(options).
-		For(&infrastructurev1beta1.OscMachineTemplate{}).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
-		Complete(r)
 }

--- a/controllers/oscmachinetemplate_capacity_controller_unit_test.go
+++ b/controllers/oscmachinetemplate_capacity_controller_unit_test.go
@@ -29,7 +29,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2/klogr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
@@ -147,9 +146,7 @@ func SetupMachineTemplate(t *testing.T, name string, clusterSpec infrastructurev
 		},
 	}
 
-	log := klogr.New()
 	clusterScope = &scope.ClusterScope{
-		Logger: log,
 		Cluster: &clusterv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				UID:       "uid",
@@ -160,7 +157,6 @@ func SetupMachineTemplate(t *testing.T, name string, clusterSpec infrastructurev
 		OscCluster: &oscCluster,
 	}
 	machineTemplateScope = &scope.MachineTemplateScope{
-		Logger:             log,
 		OscMachineTemplate: &oscMachineTemplate,
 	}
 	return clusterScope, machineTemplateScope
@@ -212,12 +208,12 @@ func TestReconcileCapacity(t *testing.T) {
 			if ctc.expGetCapacityFound {
 				mockOscVmInterface.
 					EXPECT().
-					GetCapacity(gomock.Eq(tagKey), gomock.Eq(tagValue), gomock.Eq(vmType)).
+					GetCapacity(gomock.Any(), gomock.Eq(tagKey), gomock.Eq(tagValue), gomock.Eq(vmType)).
 					Return(capacity, ctc.expReconcileCapacityErr)
 			} else {
 				mockOscVmInterface.
 					EXPECT().
-					GetCapacity(gomock.Eq(tagKey), gomock.Eq(tagValue), gomock.Eq(vmType)).
+					GetCapacity(gomock.Any(), gomock.Eq(tagKey), gomock.Eq(tagValue), gomock.Eq(vmType)).
 					Return(nil, ctc.expReconcileCapacityErr)
 			}
 

--- a/controllers/oscmachinetemplate_controller.go
+++ b/controllers/oscmachinetemplate_controller.go
@@ -21,80 +21,136 @@ import (
 	"fmt"
 	"time"
 
+	infrastructurev1beta1 "github.com/outscale/cluster-api-provider-outscale/api/v1beta1"
 	"github.com/outscale/cluster-api-provider-outscale/cloud/scope"
 	"github.com/outscale/cluster-api-provider-outscale/cloud/services/compute"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/record"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/predicates"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-// reconcileCapacity reconcile oscmachinetemplate capacity
-func reconcileCapacity(ctx context.Context, clusterScope *scope.ClusterScope, machineTemplateScope *scope.MachineTemplateScope, vmSvc compute.OscVmInterface) (reconcile.Result, error) {
-	var machineSize int
-	var machineKcpCount int32
-	var machineKwCount int32
-	var machineKcpReady int32
-	var machineKwReady int32
-	var machines []*clusterv1.Machine
-	var err error
-	vmReplica := machineTemplateScope.GetReplica()
-	if vmReplica != 1 {
-		machines, _, err = clusterScope.ListMachines(ctx)
-		if err != nil {
-			return reconcile.Result{}, fmt.Errorf("%w Can not get ListMachine", err)
-		}
-		machineSize = len(machines)
-		clusterScope.V(4).Info("Get OscMachine Size", "machineSize", machineSize)
-	} else {
-		clusterScope.V(2).Info("Do not wait for OscMachine")
-		machineSize = 1
-		machineKcpReady = 1
-		machineKcpCount = 1
-	}
+// getVmSvc retrieve vmSvc
+func (r *OscMachineTemplateReconciler) getVmSvc(ctx context.Context, scope scope.ClusterScope) compute.OscVmInterface {
+	return compute.NewService(ctx, &scope)
+}
 
-	if machineSize > 0 {
-		if vmReplica != 1 {
-			names := make([]string, len(machines))
-			for i, m := range machines {
-				names[i] = "machine/" + m.Name
-				machineTemplateScope.V(4).Info("Get Machines", "machine", m.Name)
-				machineLabel := m.Labels
-				for labelKey := range machineLabel {
-					switch labelKey {
-					case "cluster.x-k8s.io/control-plane":
-						machineTemplateScope.V(4).Info("Get Kcp Machine", "machineKcp", m.Name)
-						machineKcpCount++
-						if m.Status.Phase == "Running" || m.Status.Phase == "Provisioned" {
-							machineKcpReady++
-						}
-					case "cluster.x-k8s.io/deployment-name":
-						machineTemplateScope.V(4).Info("Get Kw Machine", "machineKw", m.Name)
-						machineKwCount++
-						if m.Status.Phase == "Running" || m.Status.Phase == "Provisioned" {
-							machineKwReady++
-						}
-					}
-				}
-			}
+type OscMachineTemplateReconciler struct {
+	client.Client
+	Recorder         record.EventRecorder
+	ReconcileTimeout time.Duration
+	WatchFilterValue string
+}
+
+// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=oscmachinetemplates,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=oscmachinetemplates/status,verbs=get;update;patch
+
+// Reconcile manages the lifecycle of an OscMachineTemplate object.
+func (r *OscMachineTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
+	log := ctrl.LoggerFrom(ctx)
+	log.V(3).Info("Reconcile OscMachineTemplate")
+
+	machineTemplate := &infrastructurev1beta1.OscMachineTemplate{}
+	if err := r.Get(ctx, req.NamespacedName, machineTemplate); err != nil {
+		if apierrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
 		}
-		role := machineTemplateScope.GetRole()
-		if role == "controlplane" && machineKcpReady > 0 && machineKcpCount > 0 {
-			machineTemplateScope.V(2).Info("At least one controlplane node ready")
-		} else if role == "" && machineKwReady > 0 && machineKwCount > 0 {
-			machineTemplateScope.V(2).Info("At least one worker node ready")
-		} else {
-			machineTemplateScope.V(2).Info("Node is not ready yet")
-			return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
-		}
-	} else {
-		return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
-	}
-	clusterName := machineTemplateScope.GetClusterName() + "-" + clusterScope.GetUID()
-	machineTemplateScope.V(4).Info("Get ClusterName", "clusterName", clusterName)
-	vmType := machineTemplateScope.GetVmType()
-	capacity, err := vmSvc.GetCapacity("OscK8sClusterID/"+clusterName, "owned", vmType)
-	if err != nil {
 		return reconcile.Result{}, err
 	}
-	machineTemplateScope.SetCapacity(capacity)
+
+	machineTemplateScope, err := scope.NewMachineTemplateScope(scope.MachineTemplateScopeParams{
+		Client:             r.Client,
+		OscMachineTemplate: machineTemplate,
+	})
+
+	if err != nil {
+		log.V(3).Error(err, "failed to get machineTemplate, requeing.")
+		return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+	}
+	clusterName := machineTemplateScope.GetClusterName()
+
+	labels := map[string]string{"ccm": clusterName + "-crs-ccm"}
+	clusterList := &clusterv1.ClusterList{}
+	cluster := clusterv1.Cluster{}
+	err = r.List(ctx, clusterList, client.InNamespace(machineTemplate.Namespace), client.MatchingLabels(labels))
+	if err != nil {
+		log.V(2).Info("Cluster is not available yet")
+		log.Error(err, "failed to get owning cluster.")
+		return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+	} else {
+		for _, cluster = range clusterList.Items {
+			log.V(4).Info("Cluster", "cluster", cluster.Name)
+		}
+		if len(clusterList.Items) == 0 {
+			log.V(3).Info("OscCluster is not available yet")
+			return reconcile.Result{RequeueAfter: 60 * time.Second}, nil
+		}
+	}
+	oscCluster := &infrastructurev1beta1.OscCluster{}
+	oscClusterName := client.ObjectKey{
+		Namespace: machineTemplate.Namespace,
+		Name:      cluster.Spec.InfrastructureRef.Name,
+	}
+	if err := r.Client.Get(ctx, oscClusterName, oscCluster); err != nil {
+		log.V(3).Info("OscCluster is not available yet")
+		return reconcile.Result{}, err
+	}
+	clusterScope, err := scope.NewClusterScope(scope.ClusterScopeParams{
+		Client:     r.Client,
+		Cluster:    &cluster,
+		OscCluster: oscCluster,
+	})
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to create scope: %w", err)
+	}
+	defer func() {
+		if err := machineTemplateScope.Close(); err != nil && reterr == nil {
+			reterr = err
+		}
+	}()
+	if !machineTemplate.ObjectMeta.DeletionTimestamp.IsZero() {
+		return r.reconcileDelete(ctx, machineTemplateScope, clusterScope)
+	}
+	return r.reconcile(ctx, machineTemplateScope, clusterScope)
+}
+
+// reconcile reconcile the creation of the machine
+func (r *OscMachineTemplateReconciler) reconcile(ctx context.Context, machineTemplateScope *scope.MachineTemplateScope, clusterScope *scope.ClusterScope) (reconcile.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+	log.V(2).Info("Reconciling OscMachineTemplate")
+	controllerutil.AddFinalizer(machineTemplateScope.OscMachineTemplate, "oscmachine.infrastructure.cluster.x-k8s.io")
+
+	if err := machineTemplateScope.PatchObject(ctx); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	vmSvc := r.getVmSvc(ctx, *clusterScope)
+	reconcileCapacity, err := reconcileCapacity(ctx, clusterScope, machineTemplateScope, vmSvc)
+	if err != nil {
+		return reconcileCapacity, err
+	}
+	return reconcileCapacity, nil
+}
+
+// reconcileDelete reconcile the deletion of the machine
+func (r *OscMachineTemplateReconciler) reconcileDelete(ctx context.Context, machineTemplateScope *scope.MachineTemplateScope, clusterScope *scope.ClusterScope) (reconcile.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+	log.V(2).Info("Reconciling delete OscMachineTemplate")
+	oscmachinetemplate := machineTemplateScope.OscMachineTemplate
+	controllerutil.RemoveFinalizer(oscmachinetemplate, "oscmachinetemplate.infrastructure.cluster.x-k8s.io")
 	return reconcile.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *OscMachineTemplateReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(options).
+		For(&infrastructurev1beta1.OscMachineTemplate{}).
+		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		Complete(r)
 }

--- a/testenv/osccluster_controller_test.go
+++ b/testenv/osccluster_controller_test.go
@@ -347,7 +347,7 @@ func checkOscNetToBeProvisioned(ctx context.Context, oscInfraClusterKey client.O
 		netSpec := clusterScope.GetNet()
 		netId := netSpec.ResourceId
 		fmt.Fprintf(GinkgoWriter, "Check NetId %s\n", netId)
-		net, err := netsvc.GetNet(netId)
+		net, err := netsvc.GetNet(ctx, netId)
 		if err != nil {
 			return err
 		}
@@ -368,7 +368,7 @@ func checkOscVmToBeProvisioned(ctx context.Context, oscInfraMachineKey client.Ob
 		vmSpec := machineScope.GetVm()
 		vmId := vmSpec.ResourceId
 		fmt.Fprintf(GinkgoWriter, "Check VmId %s\n", vmId)
-		vm, err := vmSvc.GetVm(vmId)
+		vm, err := vmSvc.GetVm(ctx, vmId)
 		if err != nil {
 			return err
 		}
@@ -390,7 +390,7 @@ func checkOscSubnetToBeProvisioned(ctx context.Context, oscInfraClusterKey clien
 		subnetsSpec := clusterScope.GetSubnet()
 		netId := netSpec.ResourceId
 		var subnetIds []string
-		subnetIds, err := netsvc.GetSubnetIdsFromNetIds(netId)
+		subnetIds, err := netsvc.GetSubnetIdsFromNetIds(ctx, netId)
 		if err != nil {
 			return err
 		}
@@ -416,7 +416,7 @@ func checkOscInternetServiceToBeProvisioned(ctx context.Context, oscInfraCluster
 		internetServiceSpec := clusterScope.GetInternetService()
 		internetServiceId := internetServiceSpec.ResourceId
 		fmt.Fprintf(GinkgoWriter, "Check InternetServiceId %s\n", internetServiceId)
-		internetService, err := netsvc.GetInternetService(internetServiceId)
+		internetService, err := netsvc.GetInternetService(ctx, internetServiceId)
 		if err != nil {
 			return err
 		}
@@ -437,7 +437,7 @@ func checkOscNatServiceToBeProvisioned(ctx context.Context, oscInfraClusterKey c
 		natServiceSpec := clusterScope.GetNatService()
 		natServiceId := natServiceSpec.ResourceId
 		fmt.Fprintf(GinkgoWriter, "Check NatServiceId %s\n", natServiceId)
-		natService, err := netsvc.GetNatService(natServiceId)
+		natService, err := netsvc.GetNatService(ctx, natServiceId)
 		if err != nil {
 			return err
 		}
@@ -462,7 +462,7 @@ func checkOscPublicIpToBeProvisioned(ctx context.Context, oscInfraClusterKey cli
 			publicIpId = publicIpSpec.ResourceId
 			publicIpIds = append(publicIpIds, publicIpId)
 		}
-		validPublicIpIds, err := securitysvc.ValidatePublicIpIds(publicIpIds)
+		validPublicIpIds, err := securitysvc.ValidatePublicIpIds(ctx, publicIpIds)
 		fmt.Fprintf(GinkgoWriter, "Check PublicIpIds has been received %s\n", validPublicIpIds)
 		if err != nil {
 			return err
@@ -487,7 +487,7 @@ func checkOscRouteTableToBeProvisioned(ctx context.Context, oscInfraClusterKey c
 		netId := netSpec.ResourceId
 		securitysvc := security.NewService(ctx, clusterScope)
 		routeTablesSpec := clusterScope.GetRouteTables()
-		routeTableIds, err := securitysvc.GetRouteTableIdsFromNetIds(netId)
+		routeTableIds, err := securitysvc.GetRouteTableIdsFromNetIds(ctx, netId)
 		fmt.Fprintf(GinkgoWriter, "Check RouteTableIds has been received %v \n", routeTableIds)
 
 		if err != nil {
@@ -532,7 +532,7 @@ func checkOscRouteToBeProvisioned(ctx context.Context, oscInfraClusterKey client
 				}
 				fmt.Fprintf(GinkgoWriter, "Check RouteTable %s %s %s\n", routeTableId, resourceId, resourceType)
 
-				routeTableFromRoute, err := securitysvc.GetRouteTableFromRoute(routeTableId, resourceId, resourceType)
+				routeTableFromRoute, err := securitysvc.GetRouteTableFromRoute(ctx, routeTableId, resourceId, resourceType)
 				if err != nil {
 					return err
 				}
@@ -555,7 +555,7 @@ func checkOscSecurityGroupToBeProvisioned(ctx context.Context, oscInfraClusterKe
 		netId := netSpec.ResourceId
 		securitysvc := security.NewService(ctx, clusterScope)
 		securityGroupsSpec := clusterScope.GetSecurityGroups()
-		securityGroupIds, err := securitysvc.GetSecurityGroupIdsFromNetIds(netId)
+		securityGroupIds, err := securitysvc.GetSecurityGroupIdsFromNetIds(ctx, netId)
 		fmt.Fprintf(GinkgoWriter, "Check SecurityGroupIds received %v \n", securityGroupIds)
 		if err != nil {
 			return err
@@ -590,7 +590,7 @@ func checkOscSecurityGroupRuleToBeProvisioned(ctx context.Context, oscInfraClust
 				IpRange := securityGroupRuleSpec.IpRange
 				FromPortRange := securityGroupRuleSpec.FromPortRange
 				ToPortRange := securityGroupRuleSpec.ToPortRange
-				securityGroupFromSecurityGroupRule, err := securitysvc.GetSecurityGroupFromSecurityGroupRule(securityGroupId, Flow, IpProtocol, IpRange, "", FromPortRange, ToPortRange)
+				securityGroupFromSecurityGroupRule, err := securitysvc.GetSecurityGroupFromSecurityGroupRule(ctx, securityGroupId, Flow, IpProtocol, IpRange, "", FromPortRange, ToPortRange)
 				if err != nil {
 					return err
 				}
@@ -611,7 +611,7 @@ func checkOscLoadBalancerToBeProvisioned(ctx context.Context, oscInfraClusterKey
 	Eventually(func() error {
 		servicesvc := service.NewService(ctx, clusterScope)
 		loadBalancerSpec := clusterScope.GetLoadBalancer()
-		loadbalancer, err := servicesvc.GetLoadBalancer(loadBalancerSpec)
+		loadbalancer, err := servicesvc.GetLoadBalancer(ctx, loadBalancerSpec)
 		loadBalancerName := loadBalancerSpec.LoadBalancerName
 		fmt.Fprintf(GinkgoWriter, "Check loadBalancer %s\n", loadBalancerName)
 		if err != nil {


### PR DESCRIPTION
- OAPI debug log are disabled and replaced with more compact ones
- context is forwarded to cloud calls & stores the logger
- cleanup of verbosities and removal of some logs