### PR TITLE
🐛 fix: unable to delete oscmachinetemplate

### DIFF
--- a/cloud/scope/machinetemplate.go
+++ b/cloud/scope/machinetemplate.go
@@ -75,8 +75,8 @@ type MachineTemplateScope struct {
 }
 
 // Close closes the scope of the machine configuration and status
-func (m *MachineTemplateScope) Close() error {
-	return m.patchHelper.Patch(context.TODO(), m.OscMachineTemplate)
+func (m *MachineTemplateScope) Close(ctx context.Context) error {
+	return m.patchHelper.Patch(ctx, m.OscMachineTemplate)
 }
 
 // GetName return the name of the machine


### PR DESCRIPTION
* If cluster ressources are deleted before oscmachinetemplate, oscmachinetemplate could not be deleted,
* The finalizer added was not the same that the finalizer removed => a finalizer was kept, leading to a never deleted resource

As oscmachinetemplate do not create anything, there is no need for finalizers & delete reconciliation. We stop setting it (but keep removing the one that previously set for compatibility purposes).
