### PR TITLE
fix(oscmachine): Remove finalizer when vmid remains empty

### DIFF
--- a/controllers/oscmachine_vm_controller.go
+++ b/controllers/oscmachine_vm_controller.go
@@ -34,6 +34,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -602,6 +603,7 @@ func reconcileDeleteVm(ctx context.Context, clusterScope *scope.ClusterScope, ma
 	}
 	if vmId == "" {
 		log.V(2).Info("vm is already destroyed", "vmName", vmName)
+		controllerutil.RemoveFinalizer(machineScope.OscMachine, "")
 		return reconcile.Result{}, nil
 	}
 	log.V(4).Info("Get vmId", "vmId", vmId)


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature           New functionality with test.
/kind bug               Fixes a newly discovered bug.
/kind api-change        Adds, removes, or changes an API
/kind cleanup           Adding tests, refactoring, fixing old bugs.
/kind deprecation       Related to a feature/enhancement marked for deprecation.
/kind regression        Related to a regression.
/kind documentation     Adds documentation.
/kind other             Related to updating dependencies, minor changes or other.
-->

**What this PR does / why we need it**:

Fixes #434

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
