### PR TITLE
🐛 fix/oscmachine: unable to delete cp vm if vm is not registered in LBU anymore

### DIFF
--- a/cloud/services/service/mock_service/loadbalancer_mock.go
+++ b/cloud/services/service/mock_service/loadbalancer_mock.go
@@ -124,18 +124,18 @@ func (mr *MockOscLoadBalancerInterfaceMockRecorder) DeleteLoadBalancerTag(ctx, s
 }
 
 // GetLoadBalancer mocks base method.
-func (m *MockOscLoadBalancerInterface) GetLoadBalancer(ctx context.Context, spec *v1beta1.OscLoadBalancer) (*osc.LoadBalancer, error) {
+func (m *MockOscLoadBalancerInterface) GetLoadBalancer(ctx context.Context, loadBalancerName string) (*osc.LoadBalancer, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLoadBalancer", ctx, spec)
+	ret := m.ctrl.Call(m, "GetLoadBalancer", ctx, loadBalancerName)
 	ret0, _ := ret[0].(*osc.LoadBalancer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetLoadBalancer indicates an expected call of GetLoadBalancer.
-func (mr *MockOscLoadBalancerInterfaceMockRecorder) GetLoadBalancer(ctx, spec interface{}) *gomock.Call {
+func (mr *MockOscLoadBalancerInterfaceMockRecorder) GetLoadBalancer(ctx, loadBalancerName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLoadBalancer", reflect.TypeOf((*MockOscLoadBalancerInterface)(nil).GetLoadBalancer), ctx, spec)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLoadBalancer", reflect.TypeOf((*MockOscLoadBalancerInterface)(nil).GetLoadBalancer), ctx, loadBalancerName)
 }
 
 // GetLoadBalancerTag mocks base method.

--- a/controllers/osccluster_loadbalancer_controller.go
+++ b/controllers/osccluster_loadbalancer_controller.go
@@ -152,7 +152,7 @@ func reconcileLoadBalancer(ctx context.Context, clusterScope *scope.ClusterScope
 	log := ctrl.LoggerFrom(ctx)
 	loadBalancerSpec := clusterScope.GetLoadBalancer()
 	loadBalancerName := loadBalancerSpec.LoadBalancerName
-	loadbalancer, err := loadBalancerSvc.GetLoadBalancer(ctx, loadBalancerSpec)
+	loadbalancer, err := loadBalancerSvc.GetLoadBalancer(ctx, loadBalancerName)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("cannot get loadbalancer: %w", err)
 	}
@@ -229,7 +229,7 @@ func reconcileDeleteLoadBalancer(ctx context.Context, clusterScope *scope.Cluste
 	loadBalancerSpec.SetDefaultValue()
 	loadBalancerName := loadBalancerSpec.LoadBalancerName
 
-	loadbalancer, err := loadBalancerSvc.GetLoadBalancer(ctx, loadBalancerSpec)
+	loadbalancer, err := loadBalancerSvc.GetLoadBalancer(ctx, loadBalancerName)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/testenv/osccluster_controller_test.go
+++ b/testenv/osccluster_controller_test.go
@@ -611,8 +611,8 @@ func checkOscLoadBalancerToBeProvisioned(ctx context.Context, oscInfraClusterKey
 	Eventually(func() error {
 		servicesvc := service.NewService(ctx, clusterScope)
 		loadBalancerSpec := clusterScope.GetLoadBalancer()
-		loadbalancer, err := servicesvc.GetLoadBalancer(ctx, loadBalancerSpec)
 		loadBalancerName := loadBalancerSpec.LoadBalancerName
+		loadbalancer, err := servicesvc.GetLoadBalancer(ctx, loadBalancerName)
 		fmt.Fprintf(GinkgoWriter, "Check loadBalancer %s\n", loadBalancerName)
 		if err != nil {
 			return err


### PR DESCRIPTION
Sometimes, a control plane oscmachine is removed from the LBU but vm cannot be deleted.

Next reconciler runs are stuck trying to remove VM from the LBU.

Some unit tests are redundant and are removed. Others are simplified for improved readability.