### PR TITLE
🚨 lint: XxxScope.Close() should forward context

### DIFF
--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -92,8 +92,8 @@ type ClusterScope struct {
 }
 
 // Close closes the scope of the cluster configuration and status
-func (s *ClusterScope) Close() error {
-	return s.patchHelper.Patch(context.TODO(), s.OscCluster)
+func (s *ClusterScope) Close(ctx context.Context) error {
+	return s.patchHelper.Patch(ctx, s.OscCluster)
 }
 
 // GetName return the name of the cluster

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -104,8 +104,8 @@ type MachineScope struct {
 }
 
 // Close closes the scope of the machine configuration and status
-func (m *MachineScope) Close() error {
-	return m.patchHelper.Patch(context.TODO(), m.OscMachine)
+func (m *MachineScope) Close(ctx context.Context) error {
+	return m.patchHelper.Patch(ctx, m.OscMachine)
 }
 
 // GetName return the name of the machine

--- a/controllers/osccluster_controller.go
+++ b/controllers/osccluster_controller.go
@@ -155,7 +155,7 @@ func (r *OscClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return reconcile.Result{}, fmt.Errorf("failed to create scope: %w", err)
 	}
 	defer func() {
-		if err := clusterScope.Close(); err != nil && reterr == nil {
+		if err := clusterScope.Close(ctx); err != nil && reterr == nil {
 			reterr = err
 		}
 	}()

--- a/controllers/oscmachine_controller.go
+++ b/controllers/oscmachine_controller.go
@@ -176,7 +176,7 @@ func (r *OscMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return reconcile.Result{}, fmt.Errorf("failed to create scope: %w", err)
 	}
 	defer func() {
-		if err := machineScope.Close(); err != nil && reterr == nil {
+		if err := machineScope.Close(ctx); err != nil && reterr == nil {
 			reterr = err
 		}
 	}()


### PR DESCRIPTION
MachineTemplateScope is fixed in another PR