### PR TITLE
fix(helm): Fix watch-filter argument making pods crashing

### DIFF
--- a/helm/clusterapioutscale/templates/deployment.yaml
+++ b/helm/clusterapioutscale/templates/deployment.yaml
@@ -36,9 +36,6 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v={{ .verbosity }}
-        {{- if .watchFilter }}
-        - --watch-filter {{ .watchFilter }}
-        {{- end}}
         image: {{ .proxyImage }}:{{ .proxyImageTag }}
         name: kube-rbac-proxy
         ports:
@@ -59,6 +56,9 @@ spec:
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
         - --zap-log-level={{ .verbosity }}
+        {{- if .watchFilter }}
+        - --watch-filter={{ .watchFilter }}
+        {{- end}}
         command:
         - /manager
         env:


### PR DESCRIPTION
Moving the --watch-filter argument from kube-rbac-proxy container to manager one to be really applied

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixing the helm chart when used with a given argument (watchFilter)

**Which issue(s) this PR fixes**:
Fixes #442

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [X] includes documentation
- [X] adds unit tests
