### PR TITLE
🐛 fix: many network resources were not deleted during delete reconciliation

### DIFF
--- a/controllers/osccluster_internetservice_controller_unit_test.go
+++ b/controllers/osccluster_internetservice_controller_unit_test.go
@@ -847,7 +847,7 @@ func TestReconcileDeleteInternetServiceDelete(t *testing.T) {
 	}
 }
 
-// TestReconcileDeleteInternetServiceResourceId has several tests to cover the code of the function reconcileDeleteInternetService
+// TestReconcileDeleteInternetServiceResourceId tests that reconcileDeleteInternetService does nothing if no net is known.
 func TestReconcileDeleteInternetServiceResourceId(t *testing.T) {
 	internetServiceTestCases := []struct {
 		name                                 string
@@ -859,12 +859,10 @@ func TestReconcileDeleteInternetServiceResourceId(t *testing.T) {
 			spec: infrastructurev1beta1.OscClusterSpec{
 				Network: infrastructurev1beta1.OscNetwork{},
 			},
-			expReconcileDeleteInternetServiceErr: errors.New("get net: cluster-api-net-uid does not exist"),
 		},
 		{
-			name:                                 "net does not exist",
-			spec:                                 defaultInternetServiceInitialize,
-			expReconcileDeleteInternetServiceErr: errors.New("get net: test-net-uid does not exist"),
+			name: "net does not exist",
+			spec: defaultInternetServiceInitialize,
 		},
 	}
 

--- a/controllers/osccluster_loadbalancer_controller.go
+++ b/controllers/osccluster_loadbalancer_controller.go
@@ -28,7 +28,6 @@ import (
 	osc "github.com/outscale/osc-sdk-go/v2"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -224,7 +223,6 @@ func reconcileLoadBalancer(ctx context.Context, clusterScope *scope.ClusterScope
 
 func reconcileDeleteLoadBalancer(ctx context.Context, clusterScope *scope.ClusterScope, loadBalancerSvc service.OscLoadBalancerInterface) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	osccluster := clusterScope.OscCluster
 	loadBalancerSpec := clusterScope.GetLoadBalancer()
 	loadBalancerSpec.SetDefaultValue()
 	loadBalancerName := loadBalancerSpec.LoadBalancerName
@@ -235,7 +233,6 @@ func reconcileDeleteLoadBalancer(ctx context.Context, clusterScope *scope.Cluste
 	}
 	if loadbalancer == nil {
 		log.V(4).Info("The loadBalancer is already deleted", "loadBalancerName", loadBalancerName)
-		controllerutil.RemoveFinalizer(osccluster, "oscclusters.infrastructure.cluster.x-k8s.io")
 		return reconcile.Result{}, nil
 	}
 	name := loadBalancerName + "-" + clusterScope.GetUID()

--- a/controllers/osccluster_net_controller.go
+++ b/controllers/osccluster_net_controller.go
@@ -26,7 +26,6 @@ import (
 	tag "github.com/outscale/cluster-api-provider-outscale/cloud/tag"
 	osc "github.com/outscale/osc-sdk-go/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -103,7 +102,6 @@ func reconcileNet(ctx context.Context, clusterScope *scope.ClusterScope, netSvc 
 // reconcileDeleteNet reconcile the destruction of the Net of the cluster.
 func reconcileDeleteNet(ctx context.Context, clusterScope *scope.ClusterScope, netSvc net.OscNetInterface) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	osccluster := clusterScope.OscCluster
 
 	netSpec := clusterScope.GetNet()
 	netSpec.SetDefaultValue()
@@ -115,7 +113,6 @@ func reconcileDeleteNet(ctx context.Context, clusterScope *scope.ClusterScope, n
 	}
 	if net == nil {
 		log.V(4).Info("The net is already deleted", "netName", netName)
-		controllerutil.RemoveFinalizer(osccluster, "oscclusters.infrastructure.cluster.x-k8s.io")
 		return reconcile.Result{}, nil
 	}
 	log.V(2).Info("Deleting net", "netName", netName)

--- a/controllers/osccluster_publicip_controller.go
+++ b/controllers/osccluster_publicip_controller.go
@@ -26,7 +26,6 @@ import (
 	"github.com/outscale/cluster-api-provider-outscale/cloud/services/security"
 	tag "github.com/outscale/cluster-api-provider-outscale/cloud/tag"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -174,7 +173,6 @@ func reconcilePublicIp(ctx context.Context, clusterScope *scope.ClusterScope, pu
 // reconcileDeletePublicIp reconcile the destruction of the PublicIp of the cluster.
 func reconcileDeletePublicIp(ctx context.Context, clusterScope *scope.ClusterScope, publicIpSvc security.OscPublicIpInterface) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	osccluster := clusterScope.OscCluster
 	var publicIpsSpec []*infrastructurev1beta1.OscPublicIp
 	networkSpec := clusterScope.GetNetwork()
 	if networkSpec.PublicIps == nil {
@@ -200,7 +198,6 @@ func reconcileDeletePublicIp(ctx context.Context, clusterScope *scope.ClusterSco
 		log.V(4).Info("Check publicIp Id", "publicipid", publicIpId)
 		publicIpName := publicIpSpec.Name + "-" + clusterScope.GetUID()
 		if !slices.Contains(validPublicIpIds, publicIpId) {
-			controllerutil.RemoveFinalizer(osccluster, "oscclusters.infrastructure.cluster.x-k8s.io")
 			return reconcile.Result{}, nil
 		}
 		err = publicIpSvc.CheckPublicIpUnlink(ctx, 5, 120, publicIpId)

--- a/controllers/osccluster_securitygroup_controller_unit_test.go
+++ b/controllers/osccluster_securitygroup_controller_unit_test.go
@@ -1986,27 +1986,22 @@ func TestReconcileDeleteSecurityGroupGet(t *testing.T) {
 	}
 }
 
-// TestReconcileDeleteSecurityGroupResourceId has several tests to cover the code of the function reconcileDeleteSecurityGroup
-func TestReconcileDeleteSecurityGroupResourceId(t *testing.T) {
+// TestReconcileDeleteSecurityGroup_NoNetKnown tests that reconciliation succeeds if no net is known
+func TestReconcileDeleteSecurityGroup_NoNetKnown(t *testing.T) {
 	securityGroupTestCases := []struct {
 		name                               string
 		spec                               infrastructurev1beta1.OscClusterSpec
-		expNetFound                        bool
 		expReconcileDeleteSecurityGroupErr error
 	}{
 		{
-			name:                               "net does not exist",
-			spec:                               defaultSecurityGroupReconcile,
-			expNetFound:                        false,
-			expReconcileDeleteSecurityGroupErr: errors.New("test-net-uid does not exist"),
+			name: "net does not exist",
+			spec: defaultSecurityGroupReconcile,
 		},
 		{
 			name: "check failed without net and securityGroup spec (retrieve default values cluster-api)",
 			spec: infrastructurev1beta1.OscClusterSpec{
 				Network: infrastructurev1beta1.OscNetwork{},
 			},
-			expNetFound:                        false,
-			expReconcileDeleteSecurityGroupErr: errors.New("cluster-api-net-uid does not exist"),
 		},
 	}
 	for _, sgtc := range securityGroupTestCases {

--- a/controllers/osccluster_subnet_controller_unit_test.go
+++ b/controllers/osccluster_subnet_controller_unit_test.go
@@ -824,24 +824,22 @@ func TestReconcileDeleteSubnetDelete(t *testing.T) {
 	}
 }
 
-// TestReconcileDeleteSubnetResourceId has several tests to cover the code of the function reconcileDeleteSubnet
-func TestReconcileDeleteSubnetResourceId(t *testing.T) {
+// TestReconcileDeleteSubnet_NoNetKnown tests that reconciliation suceeds if no net is known
+func TestReconcileDeleteSubnet_NoNetKnown(t *testing.T) {
 	subnetTestCases := []struct {
 		name                        string
 		spec                        infrastructurev1beta1.OscClusterSpec
 		expReconcileDeleteSubnetErr error
 	}{
 		{
-			name:                        "Net does not exist",
-			spec:                        defaultSubnetReconcile,
-			expReconcileDeleteSubnetErr: errors.New("test-net-uid does not exist"),
+			name: "Net does not exist",
+			spec: defaultSubnetReconcile,
 		},
 		{
 			name: "check failed without net and subnet spec (retrieve default values cluster-api)",
 			spec: infrastructurev1beta1.OscClusterSpec{
 				Network: infrastructurev1beta1.OscNetwork{},
 			},
-			expReconcileDeleteSubnetErr: errors.New("cluster-api-net-uid does not exist"),
 		},
 	}
 	for _, stc := range subnetTestCases {

--- a/controllers/oscmachine_keypair_controller.go
+++ b/controllers/oscmachine_keypair_controller.go
@@ -131,7 +131,7 @@ func reconcileDeleteKeypair(ctx context.Context, machineScope *scope.MachineScop
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("cannot get keypair: %w", err)
 	}
-	if keypair == nil { // FIXME: this never occurs, an error should be returned by GetKeyPair
+	if keypair == nil {
 		log.V(3).Info("Keypair is already deleted", "keypair", keypairName)
 		return reconcile.Result{}, nil
 	}


### PR DESCRIPTION
Delete reconciliation could not delete routes because route deletion required an internet service that was deleted just before.

When retrying, the reconciler found no load balancer and stopped the delete reconciliation, removing the finalizer, and leaving all resources that are supposed to be deleted after route tables (security groups, internet services, nets & subnets).

There are multiple places where the finalizer was removed without being sure that all network resources were all deleted.

When deleting an uninitialized cluster, no net id is present in the spec. We need to ensure that reconciliation succeeds. As most resources depend on a net, no deletion is attempted for those without a known net id.