### PR TITLE
♻️ refacto/oscmachinetemplate: set status.capacity from vmspec without waiting for vm

### DIFF
--- a/cloud/services/compute/mock_compute/vm_mock.go
+++ b/cloud/services/compute/mock_compute/vm_mock.go
@@ -12,7 +12,6 @@ import (
 	v1beta1 "github.com/outscale/cluster-api-provider-outscale/api/v1beta1"
 	scope "github.com/outscale/cluster-api-provider-outscale/cloud/scope"
 	osc "github.com/outscale/osc-sdk-go/v2"
-	v1 "k8s.io/api/core/v1"
 )
 
 // MockOscVmInterface is a mock of OscVmInterface interface.
@@ -94,21 +93,6 @@ func (m *MockOscVmInterface) DeleteVm(ctx context.Context, vmId string) error {
 func (mr *MockOscVmInterfaceMockRecorder) DeleteVm(ctx, vmId interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVm", reflect.TypeOf((*MockOscVmInterface)(nil).DeleteVm), ctx, vmId)
-}
-
-// GetCapacity mocks base method.
-func (m *MockOscVmInterface) GetCapacity(ctx context.Context, tagKey, tagValue, vmType string) (v1.ResourceList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCapacity", ctx, tagKey, tagValue, vmType)
-	ret0, _ := ret[0].(v1.ResourceList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCapacity indicates an expected call of GetCapacity.
-func (mr *MockOscVmInterfaceMockRecorder) GetCapacity(ctx, tagKey, tagValue, vmType interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCapacity", reflect.TypeOf((*MockOscVmInterface)(nil).GetCapacity), ctx, tagKey, tagValue, vmType)
 }
 
 // GetVm mocks base method.

--- a/controllers/oscmachinetemplate_capacity_controller.go
+++ b/controllers/oscmachinetemplate_capacity_controller.go
@@ -19,82 +19,47 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"time"
+	"regexp"
 
 	"github.com/outscale/cluster-api-provider-outscale/cloud/scope"
-	"github.com/outscale/cluster-api-provider-outscale/cloud/services/compute"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-// reconcileCapacity reconcile oscmachinetemplate capacity
-func reconcileCapacity(ctx context.Context, clusterScope *scope.ClusterScope, machineTemplateScope *scope.MachineTemplateScope, vmSvc compute.OscVmInterface) (reconcile.Result, error) {
-	log := ctrl.LoggerFrom(ctx)
-	var machineSize int
-	var machineKcpCount int32
-	var machineKwCount int32
-	var machineKcpReady int32
-	var machineKwReady int32
-	var machines []*clusterv1.Machine
-	var err error
-	vmReplica := machineTemplateScope.GetReplica()
-	if vmReplica != 1 {
-		machines, _, err = clusterScope.ListMachines(ctx)
-		if err != nil {
-			return reconcile.Result{}, fmt.Errorf("cannot get ListMachine: %w", err)
-		}
-		machineSize = len(machines)
-		log.V(4).Info("Get OscMachine Size", "machineSize", machineSize)
-	} else {
-		log.V(3).Info("Do not wait for OscMachine")
-		machineSize = 1
-		machineKcpReady = 1
-		machineKcpCount = 1
-	}
+var reVmType = regexp.MustCompile("tinav[0-9]+.c([0-9]+)r([0-9]+)p[0-9]+")
 
-	if machineSize > 0 {
-		if vmReplica != 1 {
-			names := make([]string, len(machines))
-			for i, m := range machines {
-				names[i] = "machine/" + m.Name
-				machineLabel := m.Labels
-				for labelKey := range machineLabel {
-					switch labelKey {
-					case "cluster.x-k8s.io/control-plane":
-						log.V(4).Info("Control plane", "machineKcp", m.Name)
-						machineKcpCount++
-						if m.Status.Phase == "Running" || m.Status.Phase == "Provisioned" {
-							machineKcpReady++
-						}
-					case "cluster.x-k8s.io/deployment-name":
-						log.V(4).Info("Worker", "machineKw", m.Name)
-						machineKwCount++
-						if m.Status.Phase == "Running" || m.Status.Phase == "Provisioned" {
-							machineKwReady++
-						}
-					}
-				}
-			}
-		}
-		role := machineTemplateScope.GetRole()
-		if role == "controlplane" && machineKcpReady > 0 && machineKcpCount > 0 {
-			log.V(3).Info("At least one controlplane node ready")
-		} else if role == "" && machineKwReady > 0 && machineKwCount > 0 {
-			log.V(3).Info("At least one worker node ready")
-		} else {
-			log.V(3).Info("Node is not ready yet")
-			return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
-		}
-	} else {
-		return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
-	}
-	clusterName := machineTemplateScope.GetClusterName() + "-" + clusterScope.GetUID()
+// reconcileCapacity reconcile oscmachinetemplate capacity
+func reconcileCapacity(ctx context.Context, machineTemplateScope *scope.MachineTemplateScope) (reconcile.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+
 	vmType := machineTemplateScope.GetVmType()
-	capacity, err := vmSvc.GetCapacity(ctx, "OscK8sClusterID/"+clusterName, "owned", vmType)
-	if err != nil {
-		return reconcile.Result{}, err
+	if vmType == "" {
+		return reconcile.Result{}, nil
 	}
+	matches := reVmType.FindStringSubmatch(vmType)
+	if len(matches) == 0 {
+		log.V(5).Info("status.capacity is only computed for tina vm types")
+		return reconcile.Result{}, nil
+	}
+	capacity := corev1.ResourceList{}
+
+	cpu, err := resource.ParseQuantity(matches[1])
+	if err != nil {
+		log.V(5).Error(err, "unable to compute cpu capacity for autoscaler")
+		return reconcile.Result{}, nil
+	}
+	capacity[corev1.ResourceCPU] = cpu
+
+	mem, err := resource.ParseQuantity(matches[2] + "Gi")
+	if err != nil {
+		log.V(5).Error(err, "unable to compute memory capacity for autoscaler")
+		return reconcile.Result{}, nil
+	}
+	capacity[corev1.ResourceMemory] = mem
+
+	log.V(3).Info(fmt.Sprintf("Setting status.capacity to %v", capacity))
 	machineTemplateScope.SetCapacity(capacity)
 	return reconcile.Result{}, nil
 }


### PR DESCRIPTION
When implementing scale-to-zero autoscaling, the autoscaler requires having status.capacity in infrastructure machine templates.

The former implementation waited for vms to be up, and queried OAPI to get the vmType.

As the vmType is defined in the spec, we can set status.capacity from the spec. This saves a lot of reconciliations.

This only works with tina machine types, not aws style types, but only tina machine types pass validation.