### PR TITLE
Enable port 2380 for ETCD in SG. Add region for osc-secret and create namespace

### DIFF
--- a/example/cluster-machine-template-bastion.yaml
+++ b/example/cluster-machine-template-bastion.yaml
@@ -168,7 +168,7 @@ spec:
 # IpRange to authorize access to kubernetes endpoints (kube-apiserver), you must keep it and change it with a CIDR that best suits with your environment.
             ipRange: "10.0.0.32/28"
             fromPortRange: 2378
-            toPortRange: 2379
+            toPortRange: 2380
           - name: cluster-api-securitygrouprule-kubelet-kcp
             flow: Inbound
             ipProtocol: tcp

--- a/example/cluster-machine-template-simple-taint.yaml
+++ b/example/cluster-machine-template-simple-taint.yaml
@@ -146,7 +146,7 @@ spec:
 # IpRange to authorize access to kubernetes endpoints (kube-apiserver), you must keep it and change it with a CIDR that best suits with your environment.
             ipRange: "10.0.4.0/24"
             fromPortRange: 2378
-            toPortRange: 2379
+            toPortRange: 2380
           - name: cluster-api-securitygrouprule-kubelet-kcp
             flow: Inbound
             ipProtocol: tcp

--- a/example/cluster-machine-template-simple.yaml
+++ b/example/cluster-machine-template-simple.yaml
@@ -150,7 +150,7 @@ spec:
 # IpRange to authorize access to kubernetes endpoints (kube-apiserver), you must keep it and change it with a CIDR that best suits with your environment.
             ipRange: "10.0.4.0/24"
             fromPortRange: 2378
-            toPortRange: 2379
+            toPortRange: 2380
           - name: cluster-api-securitygrouprule-kubelet-kcp
             flow: Inbound
             ipProtocol: tcp

--- a/osc-secret.yaml
+++ b/osc-secret.yaml
@@ -1,8 +1,14 @@
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: cluster-api-provider-outscale-system
+---
+apiVersion: v1
 kind: Secret
 metadata:
   name: cluster-api-provider-outscale
   namespace: cluster-api-provider-outscale-system
 stringData:
-  access_key: ""
-  secret_key: ""
+  region: eu-west-2
+  access_key: "XXXXX"
+  secret_key: "XXXXX"


### PR DESCRIPTION
Summary:
* Add port 2380 to SG and create namespace


Description:
* Security Groups should have port 2380 enabled to allow ETCD Peering
* region: eu-west-2 // region is required i used eu-west-2 as placeholder
* Added namespace creation for the outscale api cluster

@alistarle @airklizz cf
