### PR TITLE
✨ Use network resources managed outside cluster api

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -151,6 +151,9 @@ type OscNet struct {
 	// The Net Id response
 	// +optional
 	ResourceId string `json:"resourceId,omitempty"`
+	// The flag to determine if the reconciliation loop should be skipped
+	// +optional
+	SkipReconcile bool `json:"skipReconcile,omitempty"`
 }
 
 type OscInternetService struct {
@@ -163,6 +166,9 @@ type OscInternetService struct {
 	// the Internet Service response
 	// +optional
 	ResourceId string `json:"resourceId,omitempty"`
+	// The flag to determine if the reconciliation loop should be skipped
+	// +optional
+	SkipReconcile bool `json:"skipReconcile,omitempty"`
 }
 
 type OscSubnet struct {
@@ -178,6 +184,9 @@ type OscSubnet struct {
 	// The Subnet Id response
 	// +optional
 	ResourceId string `json:"resourceId,omitempty"`
+	// The flag to determine if the reconciliation loop should be skipped
+	// +optional
+	SkipReconcile bool `json:"skipReconcile,omitempty"`
 }
 
 type OscNatService struct {
@@ -196,6 +205,9 @@ type OscNatService struct {
 	// The Nat Service Id response
 	// +optional
 	ResourceId string `json:"resourceId,omitempty"`
+	// The flag to determine if the reconciliation loop should be skipped
+	// +optional
+	SkipReconcile bool `json:"skipReconcile,omitempty"`
 }
 
 type OscRouteTable struct {
@@ -236,6 +248,9 @@ type OscPublicIp struct {
 	// +optional
 	ResourceId  string `json:"resourceId,omitempty"`
 	ClusterName string `json:"clusterName,omitempty"`
+	// The flag to determine if the reconciliation loop should be skipped
+	// +optional
+	SkipReconcile bool `json:"skipReconcile,omitempty"`
 }
 
 type OscRoute struct {

--- a/controllers/osccluster_net_controller.go
+++ b/controllers/osccluster_net_controller.go
@@ -64,11 +64,14 @@ func reconcileNet(ctx context.Context, clusterScope *scope.ClusterScope, netSvc 
 	netRef := clusterScope.GetNetRef()
 	netName := netSpec.Name + "-" + clusterScope.GetUID()
 	clusterName := netSpec.ClusterName + "-" + clusterScope.GetUID()
-
 	var net *osc.Net
 	var err error
 	if len(netRef.ResourceMap) == 0 {
 		netRef.ResourceMap = make(map[string]string)
+	}
+	if netSpec.ResourceId != "" && netSpec.SkipReconcile {
+		netRef.ResourceMap[netName] = netSpec.ResourceId
+		return reconcile.Result{}, nil
 	}
 	tagKey := "Name"
 	tagValue := netName
@@ -107,6 +110,10 @@ func reconcileDeleteNet(ctx context.Context, clusterScope *scope.ClusterScope, n
 	netSpec.SetDefaultValue()
 	netId := netSpec.ResourceId
 	netName := netSpec.Name + "-" + clusterScope.GetUID()
+	if netSpec.SkipReconcile {
+		log.V(2).Info("Not deleting net because skip reconcile true", "netName", netName)
+		return reconcile.Result{}, nil
+	}
 	net, err := netSvc.GetNet(ctx, netId)
 	if err != nil {
 		return reconcile.Result{}, err


### PR DESCRIPTION
**What type of PR is this?**

/kind feature    
/kind bug


**What this PR does / why we need it**:

By default, cluster API outscale provider create all network object: NatGW/PublicIP/IS/Net/Subnet. In our use case, we import all these object in the cluster YAML definition using the “resourceId” field. Nevertheless, when deleting a cluster with resource imported using “resourceId” field, some resources are deleted and it should not be the case. We should fix the outscale provider to prevent that.

Code of the outscale API provider:[GitHub - outscale/cluster-api-provider-outscale](https://github.com/outscale/cluster-api-provider-outscale/tree/main) 

Issue is already opened : [[Feature]: Allow to reuse parts of existing infrastructure · Issue #381 · outscale/cluster-api-provider-outscale](https://github.com/outscale/cluster-api-provider-outscale/issues/381) 

Controller to fix to not clean resources when a resourceId is given as an input in YAML: 

* NatGW: [cluster-api-provider-outscale/controllers/osccluster_natservice_controller.go at main · outscale/cluster-api-provider-outscale](https://github.com/outscale/cluster-api-provider-outscale/blob/main/controllers/osccluster_natservice_controller.go#L185) 

* PublicIP: [cluster-api-provider-outscale/controllers/osccluster_publicip_controller.go at main · outscale/cluster-api-provider-outscale](https://github.com/outscale/cluster-api-provider-outscale/blob/main/controllers/osccluster_publicip_controller.go#L177) 

* InternetService: [cluster-api-provider-outscale/controllers/osccluster_internetservice_controller.go at main · outscale/cluster-api-provider-outscale](https://github.com/outscale/cluster-api-provider-outscale/blob/main/controllers/osccluster_internetservice_controller.go#L104) 

* Net: [cluster-api-provider-outscale/controllers/osccluster_net_controller.go at main · outscale/cluster-api-provider-outscale](https://github.com/outscale/cluster-api-provider-outscale/blob/main/controllers/osccluster_net_controller.go#L105) 

* Subnet: [cluster-api-provider-outscale/controllers/osccluster_subnet_controller.go at main · outscale/cluster-api-provider-outscale](https://github.com/outscale/cluster-api-provider-outscale/blob/main/controllers/osccluster_subnet_controller.go)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #381 


- [x] squashed commits
- [x] adds unit tests
- [ ] includes documentation


cf @alistarle 
