### PR TITLE
🐛 fix/crd: add missing oscclustertemplate CRD

### DIFF
--- a/capm.yaml
+++ b/capm.yaml
@@ -10,7 +10,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: cluster-api-provider-outscale-system/cluster-api-provider-outscale-serving-cert
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3-0.20250303100717-fe6de3528e9a
   labels:
     cluster.x-k8s.io/v1alpha3: v1alpha3
     cluster.x-k8s.io/v1beta1: v1beta1
@@ -622,7 +622,497 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: cluster-api-provider-outscale-system/cluster-api-provider-outscale-serving-cert
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3-0.20250303100717-fe6de3528e9a
+  labels:
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: oscclustertemplates.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: cluster-api-provider-outscale-webhook-service
+          namespace: cluster-api-provider-outscale-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: OscClusterTemplate
+    listKind: OscClusterTemplateList
+    plural: oscclustertemplates
+    singular: oscclustertemplate
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: OscClusterTemplate is the Schema for the oscclustertemplates
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OscClusterTemplateSpec defines the desired state of OscClusterTemplate
+            properties:
+              template:
+                properties:
+                  metadata:
+                    description: |-
+                      ObjectMeta is metadata that all persisted resources must have, which includes all objects
+                      users must create. This is a copy of customizable fields from metav1.ObjectMeta.
+
+                      ObjectMeta is embedded in `Machine.Spec`, `MachineDeployment.Template` and `MachineSet.Template`,
+                      which are not top-level Kubernetes objects. Given that metav1.ObjectMeta has lots of special cases
+                      and read-only fields which end up in the generated CRD validation, having it as a subset simplifies
+                      the API and some issues that can impact user experience.
+
+                      During the [upgrade to controller-tools@v2](https://github.com/kubernetes-sigs/cluster-api/pull/1054)
+                      for v1alpha2, we noticed a failure would occur running Cluster API test suite against the new CRDs,
+                      specifically `spec.metadata.creationTimestamp in body must be of type string: "null"`.
+                      The investigation showed that `controller-tools@v2` behaves differently than its previous version
+                      when handling types from [metav1](k8s.io/apimachinery/pkg/apis/meta/v1) package.
+
+                      In more details, we found that embedded (non-top level) types that embedded `metav1.ObjectMeta`
+                      had validation properties, including for `creationTimestamp` (metav1.Time).
+                      The `metav1.Time` type specifies a custom json marshaller that, when IsZero() is true, returns `null`
+                      which breaks validation because the field isn't marked as nullable.
+
+                      In future versions, controller-tools@v2 might allow overriding the type and validation for embedded
+                      types. When that happens, this hack should be revisited.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: OscClusterSpec defines the desired state of OscCluster
+                    properties:
+                      controlPlaneEndpoint:
+                        description: APIEndpoint represents a reachable Kubernetes
+                          API endpoint.
+                        properties:
+                          host:
+                            description: The hostname on which the API server is serving.
+                            type: string
+                          port:
+                            description: The port on which the API server is serving.
+                            format: int32
+                            type: integer
+                        required:
+                        - host
+                        - port
+                        type: object
+                      network:
+                        properties:
+                          bastion:
+                            description: The bastion configuration
+                            properties:
+                              clusterName:
+                                type: string
+                              deviceName:
+                                type: string
+                              enable:
+                                type: boolean
+                              imageAccountId:
+                                type: string
+                              imageId:
+                                type: string
+                              imageName:
+                                type: string
+                              keypairName:
+                                type: string
+                              name:
+                                type: string
+                              privateIps:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    privateIp:
+                                      type: string
+                                  type: object
+                                type: array
+                              publicIpName:
+                                type: string
+                              resourceId:
+                                type: string
+                              rootDisk:
+                                properties:
+                                  rootDiskIops:
+                                    format: int32
+                                    type: integer
+                                  rootDiskSize:
+                                    format: int32
+                                    type: integer
+                                  rootDiskType:
+                                    type: string
+                                type: object
+                              securityGroupNames:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              subnetName:
+                                type: string
+                              subregionName:
+                                type: string
+                              vmType:
+                                type: string
+                            type: object
+                          clusterName:
+                            description: The name of the cluster
+                            type: string
+                          controlPlaneSubnets:
+                            description: List of subnet to spread controlPlane nodes
+                            items:
+                              type: string
+                            type: array
+                          extraSecurityGroupRule:
+                            description: Add SecurityGroup Rule after the cluster
+                              is created
+                            type: boolean
+                          image:
+                            description: The image configuration
+                            properties:
+                              accountId:
+                                type: string
+                              name:
+                                type: string
+                              resourceId:
+                                type: string
+                            type: object
+                          internetService:
+                            description: The Internet Service configuration
+                            properties:
+                              clusterName:
+                                description: the name of the cluster
+                                type: string
+                              name:
+                                description: The tag name associate with the Subnet
+                                type: string
+                              resourceId:
+                                description: the Internet Service response
+                                type: string
+                            type: object
+                          loadBalancer:
+                            description: The Load Balancer configuration
+                            properties:
+                              clusterName:
+                                type: string
+                              healthCheck:
+                                description: The healthCheck configuration  of the
+                                  Load Balancer
+                                properties:
+                                  checkinterval:
+                                    description: the time in second between two pings
+                                    format: int32
+                                    type: integer
+                                  healthythreshold:
+                                    description: the consecutive number of pings which
+                                      are successful to consider the vm healthy
+                                    format: int32
+                                    type: integer
+                                  port:
+                                    description: the HealthCheck port number
+                                    format: int32
+                                    type: integer
+                                  protocol:
+                                    description: The HealthCheck protocol ('HTTP'|'TCP')
+                                    type: string
+                                  timeout:
+                                    description: the Timeout to consider VM unhealthy
+                                    format: int32
+                                    type: integer
+                                  unhealthythreshold:
+                                    description: the consecutive number of pings which
+                                      are failed to consider the vm unhealthy
+                                    format: int32
+                                    type: integer
+                                type: object
+                              listener:
+                                description: The Listener cofiguration of the loadBalancer
+                                properties:
+                                  backendport:
+                                    description: The port on which the backend vm
+                                      will listen
+                                    format: int32
+                                    type: integer
+                                  backendprotocol:
+                                    description: The protocol ('HTTP'|'TCP') to route
+                                      the traffic to the backend vm
+                                    type: string
+                                  loadbalancerport:
+                                    description: The port on which the loadbalancer
+                                      will listen
+                                    format: int32
+                                    type: integer
+                                  loadbalancerprotocol:
+                                    description: the routing protocol ('HTTP'|'TCP')
+                                    type: string
+                                type: object
+                              loadbalancername:
+                                description: The Load Balancer unique name
+                                type: string
+                              loadbalancertype:
+                                description: The Load Balancer Type internet-facing
+                                  or internal
+                                type: string
+                              securitygroupname:
+                                description: The security group tag name associate
+                                  with a security group
+                                type: string
+                              subnetname:
+                                description: The subnet tag name associate with a
+                                  Subnet
+                                type: string
+                            type: object
+                          natService:
+                            description: The Nat Service configuration
+                            properties:
+                              clusterName:
+                                description: The name of the cluster
+                                type: string
+                              name:
+                                description: The tag name associate with the Nat Service
+                                type: string
+                              publicipname:
+                                description: The Public Ip tag name associated with
+                                  a Public Ip
+                                type: string
+                              resourceId:
+                                description: The Nat Service Id response
+                                type: string
+                              subnetname:
+                                description: The subnet tag name associate with a
+                                  Subnet
+                                type: string
+                            type: object
+                          natServices:
+                            description: The Nat Services configuration
+                            items:
+                              properties:
+                                clusterName:
+                                  description: The name of the cluster
+                                  type: string
+                                name:
+                                  description: The tag name associate with the Nat
+                                    Service
+                                  type: string
+                                publicipname:
+                                  description: The Public Ip tag name associated with
+                                    a Public Ip
+                                  type: string
+                                resourceId:
+                                  description: The Nat Service Id response
+                                  type: string
+                                subnetname:
+                                  description: The subnet tag name associate with
+                                    a Subnet
+                                  type: string
+                              type: object
+                            type: array
+                          net:
+                            description: The Net configuration
+                            properties:
+                              clusterName:
+                                description: the name of the cluster
+                                type: string
+                              ipRange:
+                                description: the net ip range with CIDR notation
+                                type: string
+                              name:
+                                description: the tag name associate with the Net
+                                type: string
+                              resourceId:
+                                description: The Net Id response
+                                type: string
+                            type: object
+                          publicIps:
+                            description: The Public Ip configuration
+                            items:
+                              properties:
+                                clusterName:
+                                  type: string
+                                name:
+                                  description: The tag name associate with the Public
+                                    Ip
+                                  type: string
+                                resourceId:
+                                  description: The Public Ip Id response
+                                  type: string
+                              type: object
+                            type: array
+                          routeTables:
+                            description: The Route Table configuration
+                            items:
+                              properties:
+                                name:
+                                  description: The tag name associate with the Route
+                                    Table
+                                  type: string
+                                resourceId:
+                                  description: The Route Table Id response
+                                  type: string
+                                routes:
+                                  description: The Route configuration
+                                  items:
+                                    properties:
+                                      destination:
+                                        description: the destination match Ip range
+                                          with CIDR notation
+                                        type: string
+                                      name:
+                                        description: The tag name associate with the
+                                          Route
+                                        type: string
+                                      resourceId:
+                                        description: The Route Id response
+                                        type: string
+                                      targetName:
+                                        description: The tag name associate with the
+                                          target resource type
+                                        type: string
+                                      targetType:
+                                        description: The target resource type which
+                                          can be Internet Service (gateway) or Nat
+                                          Service (nat-service)
+                                        type: string
+                                    type: object
+                                  type: array
+                                subnets:
+                                  description: The subnet tag name associate with
+                                    a Subnet
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            type: array
+                          securityGroups:
+                            items:
+                              properties:
+                                description:
+                                  description: The description of the security group
+                                  type: string
+                                name:
+                                  description: The tag name associate with the security
+                                    group
+                                  type: string
+                                resourceId:
+                                  description: The Security Group Id response
+                                  type: string
+                                securityGroupRules:
+                                  description: The Security Group Rules configuration
+                                  items:
+                                    properties:
+                                      flow:
+                                        description: The flow of the security group
+                                          (inbound or outbound)
+                                        type: string
+                                      fromPortRange:
+                                        description: The beginning of the port range
+                                        format: int32
+                                        type: integer
+                                      ipProtocol:
+                                        description: The ip protocol name (tcp, udp,
+                                          icmp or -1)
+                                        type: string
+                                      ipRange:
+                                        description: The ip range of the security
+                                          group rule
+                                        type: string
+                                      name:
+                                        description: The tag name associate with the
+                                          security group
+                                        type: string
+                                      resourceId:
+                                        description: The security group rule id
+                                        type: string
+                                      toPortRange:
+                                        description: The end of the port range
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  type: array
+                                tag:
+                                  type: string
+                              type: object
+                            type: array
+                          subnets:
+                            description: The Subnet configuration
+                            items:
+                              properties:
+                                ipSubnetRange:
+                                  description: Subnet Ip range with CIDR notation
+                                  type: string
+                                name:
+                                  description: The tag name associate with the Subnet
+                                  type: string
+                                resourceId:
+                                  description: The Subnet Id response
+                                  type: string
+                                subregionName:
+                                  description: The subregion name of the Subnet
+                                  type: string
+                              type: object
+                            type: array
+                          subregionName:
+                            description: The subregion name
+                            type: string
+                        type: object
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: cluster-api-provider-outscale-system/cluster-api-provider-outscale-serving-cert
+    controller-gen.kubebuilder.io/version: v0.17.3-0.20250303100717-fe6de3528e9a
   labels:
     cluster.x-k8s.io/v1alpha3: v1alpha3
     cluster.x-k8s.io/v1beta1: v1beta1
@@ -936,7 +1426,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3-0.20250303100717-fe6de3528e9a
   labels:
     cluster.x-k8s.io/v1alpha3: v1alpha3
     cluster.x-k8s.io/v1beta1: v1beta1

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_oscclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_oscclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3-0.20250303100717-fe6de3528e9a
   name: oscclusters.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_oscclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_oscclustertemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3-0.20250303100717-fe6de3528e9a
   name: oscclustertemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_oscmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_oscmachines.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3-0.20250303100717-fe6de3528e9a
   name: oscmachines.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_oscmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_oscmachinetemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3-0.20250303100717-fe6de3528e9a
   name: oscmachinetemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -6,14 +6,17 @@ commonLabels:
   cluster.x-k8s.io/v1beta1: v1beta1
 resources:
   - bases/infrastructure.cluster.x-k8s.io_oscclusters.yaml
+  - bases/infrastructure.cluster.x-k8s.io_oscclustertemplates.yaml
   - bases/infrastructure.cluster.x-k8s.io_oscmachines.yaml
   - bases/infrastructure.cluster.x-k8s.io_oscmachinetemplates.yaml
 patchesStrategicMerge:
   # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
   # patches here are for enabling the conversion webhook for each CRD
   - patches/webhook_in_oscclusters.yaml
+  - patches/webhook_in_oscclustertemplates.yaml
   - patches/webhook_in_oscmachines.yaml
   - patches/cainjection_in_oscclusters.yaml
+  - patches/cainjection_in_oscclustertemplates.yaml
   - patches/cainjection_in_oscmachines.yaml
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:

--- a/hack/ensure-controller-gen.sh
+++ b/hack/ensure-controller-gen.sh
@@ -50,7 +50,7 @@ install_controller_gen() {
 		if ! [ -d "${BIN_ROOT}" ]; then
 			mkdir -p "${BIN_ROOT}"
 		fi
-		go install -v sigs.k8s.io/controller-tools/cmd/controller-gen@master
+		go install -v sigs.k8s.io/controller-tools/cmd/controller-gen@main
 		cp "$GOPATH/bin/controller-gen" "${BIN_ROOT}/controller-gen"
 	else
 		set +x

--- a/helm/clusterapioutscale/templates/crd.yaml
+++ b/helm/clusterapioutscale/templates/crd.yaml
@@ -621,6 +621,496 @@ metadata:
   labels:
     cluster.x-k8s.io/v1alpha3: v1alpha3
     cluster.x-k8s.io/v1beta1: v1beta1
+  name: oscclustertemplates.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: cluster-api-provider-outscale-webhook-service
+          namespace: cluster-api-provider-outscale-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: OscClusterTemplate
+    listKind: OscClusterTemplateList
+    plural: oscclustertemplates
+    singular: oscclustertemplate
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: OscClusterTemplate is the Schema for the oscclustertemplates
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OscClusterTemplateSpec defines the desired state of OscClusterTemplate
+            properties:
+              template:
+                properties:
+                  metadata:
+                    description: |-
+                      ObjectMeta is metadata that all persisted resources must have, which includes all objects
+                      users must create. This is a copy of customizable fields from metav1.ObjectMeta.
+
+                      ObjectMeta is embedded in `Machine.Spec`, `MachineDeployment.Template` and `MachineSet.Template`,
+                      which are not top-level Kubernetes objects. Given that metav1.ObjectMeta has lots of special cases
+                      and read-only fields which end up in the generated CRD validation, having it as a subset simplifies
+                      the API and some issues that can impact user experience.
+
+                      During the [upgrade to controller-tools@v2](https://github.com/kubernetes-sigs/cluster-api/pull/1054)
+                      for v1alpha2, we noticed a failure would occur running Cluster API test suite against the new CRDs,
+                      specifically `spec.metadata.creationTimestamp in body must be of type string: "null"`.
+                      The investigation showed that `controller-tools@v2` behaves differently than its previous version
+                      when handling types from [metav1](k8s.io/apimachinery/pkg/apis/meta/v1) package.
+
+                      In more details, we found that embedded (non-top level) types that embedded `metav1.ObjectMeta`
+                      had validation properties, including for `creationTimestamp` (metav1.Time).
+                      The `metav1.Time` type specifies a custom json marshaller that, when IsZero() is true, returns `null`
+                      which breaks validation because the field isn't marked as nullable.
+
+                      In future versions, controller-tools@v2 might allow overriding the type and validation for embedded
+                      types. When that happens, this hack should be revisited.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: OscClusterSpec defines the desired state of OscCluster
+                    properties:
+                      controlPlaneEndpoint:
+                        description: APIEndpoint represents a reachable Kubernetes
+                          API endpoint.
+                        properties:
+                          host:
+                            description: The hostname on which the API server is serving.
+                            type: string
+                          port:
+                            description: The port on which the API server is serving.
+                            format: int32
+                            type: integer
+                        required:
+                        - host
+                        - port
+                        type: object
+                      network:
+                        properties:
+                          bastion:
+                            description: The bastion configuration
+                            properties:
+                              clusterName:
+                                type: string
+                              deviceName:
+                                type: string
+                              enable:
+                                type: boolean
+                              imageAccountId:
+                                type: string
+                              imageId:
+                                type: string
+                              imageName:
+                                type: string
+                              keypairName:
+                                type: string
+                              name:
+                                type: string
+                              privateIps:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    privateIp:
+                                      type: string
+                                  type: object
+                                type: array
+                              publicIpName:
+                                type: string
+                              resourceId:
+                                type: string
+                              rootDisk:
+                                properties:
+                                  rootDiskIops:
+                                    format: int32
+                                    type: integer
+                                  rootDiskSize:
+                                    format: int32
+                                    type: integer
+                                  rootDiskType:
+                                    type: string
+                                type: object
+                              securityGroupNames:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              subnetName:
+                                type: string
+                              subregionName:
+                                type: string
+                              vmType:
+                                type: string
+                            type: object
+                          clusterName:
+                            description: The name of the cluster
+                            type: string
+                          controlPlaneSubnets:
+                            description: List of subnet to spread controlPlane nodes
+                            items:
+                              type: string
+                            type: array
+                          extraSecurityGroupRule:
+                            description: Add SecurityGroup Rule after the cluster
+                              is created
+                            type: boolean
+                          image:
+                            description: The image configuration
+                            properties:
+                              accountId:
+                                type: string
+                              name:
+                                type: string
+                              resourceId:
+                                type: string
+                            type: object
+                          internetService:
+                            description: The Internet Service configuration
+                            properties:
+                              clusterName:
+                                description: the name of the cluster
+                                type: string
+                              name:
+                                description: The tag name associate with the Subnet
+                                type: string
+                              resourceId:
+                                description: the Internet Service response
+                                type: string
+                            type: object
+                          loadBalancer:
+                            description: The Load Balancer configuration
+                            properties:
+                              clusterName:
+                                type: string
+                              healthCheck:
+                                description: The healthCheck configuration  of the
+                                  Load Balancer
+                                properties:
+                                  checkinterval:
+                                    description: the time in second between two pings
+                                    format: int32
+                                    type: integer
+                                  healthythreshold:
+                                    description: the consecutive number of pings which
+                                      are successful to consider the vm healthy
+                                    format: int32
+                                    type: integer
+                                  port:
+                                    description: the HealthCheck port number
+                                    format: int32
+                                    type: integer
+                                  protocol:
+                                    description: The HealthCheck protocol ('HTTP'|'TCP')
+                                    type: string
+                                  timeout:
+                                    description: the Timeout to consider VM unhealthy
+                                    format: int32
+                                    type: integer
+                                  unhealthythreshold:
+                                    description: the consecutive number of pings which
+                                      are failed to consider the vm unhealthy
+                                    format: int32
+                                    type: integer
+                                type: object
+                              listener:
+                                description: The Listener cofiguration of the loadBalancer
+                                properties:
+                                  backendport:
+                                    description: The port on which the backend vm
+                                      will listen
+                                    format: int32
+                                    type: integer
+                                  backendprotocol:
+                                    description: The protocol ('HTTP'|'TCP') to route
+                                      the traffic to the backend vm
+                                    type: string
+                                  loadbalancerport:
+                                    description: The port on which the loadbalancer
+                                      will listen
+                                    format: int32
+                                    type: integer
+                                  loadbalancerprotocol:
+                                    description: the routing protocol ('HTTP'|'TCP')
+                                    type: string
+                                type: object
+                              loadbalancername:
+                                description: The Load Balancer unique name
+                                type: string
+                              loadbalancertype:
+                                description: The Load Balancer Type internet-facing
+                                  or internal
+                                type: string
+                              securitygroupname:
+                                description: The security group tag name associate
+                                  with a security group
+                                type: string
+                              subnetname:
+                                description: The subnet tag name associate with a
+                                  Subnet
+                                type: string
+                            type: object
+                          natService:
+                            description: The Nat Service configuration
+                            properties:
+                              clusterName:
+                                description: The name of the cluster
+                                type: string
+                              name:
+                                description: The tag name associate with the Nat Service
+                                type: string
+                              publicipname:
+                                description: The Public Ip tag name associated with
+                                  a Public Ip
+                                type: string
+                              resourceId:
+                                description: The Nat Service Id response
+                                type: string
+                              subnetname:
+                                description: The subnet tag name associate with a
+                                  Subnet
+                                type: string
+                            type: object
+                          natServices:
+                            description: The Nat Services configuration
+                            items:
+                              properties:
+                                clusterName:
+                                  description: The name of the cluster
+                                  type: string
+                                name:
+                                  description: The tag name associate with the Nat
+                                    Service
+                                  type: string
+                                publicipname:
+                                  description: The Public Ip tag name associated with
+                                    a Public Ip
+                                  type: string
+                                resourceId:
+                                  description: The Nat Service Id response
+                                  type: string
+                                subnetname:
+                                  description: The subnet tag name associate with
+                                    a Subnet
+                                  type: string
+                              type: object
+                            type: array
+                          net:
+                            description: The Net configuration
+                            properties:
+                              clusterName:
+                                description: the name of the cluster
+                                type: string
+                              ipRange:
+                                description: the net ip range with CIDR notation
+                                type: string
+                              name:
+                                description: the tag name associate with the Net
+                                type: string
+                              resourceId:
+                                description: The Net Id response
+                                type: string
+                            type: object
+                          publicIps:
+                            description: The Public Ip configuration
+                            items:
+                              properties:
+                                clusterName:
+                                  type: string
+                                name:
+                                  description: The tag name associate with the Public
+                                    Ip
+                                  type: string
+                                resourceId:
+                                  description: The Public Ip Id response
+                                  type: string
+                              type: object
+                            type: array
+                          routeTables:
+                            description: The Route Table configuration
+                            items:
+                              properties:
+                                name:
+                                  description: The tag name associate with the Route
+                                    Table
+                                  type: string
+                                resourceId:
+                                  description: The Route Table Id response
+                                  type: string
+                                routes:
+                                  description: The Route configuration
+                                  items:
+                                    properties:
+                                      destination:
+                                        description: the destination match Ip range
+                                          with CIDR notation
+                                        type: string
+                                      name:
+                                        description: The tag name associate with the
+                                          Route
+                                        type: string
+                                      resourceId:
+                                        description: The Route Id response
+                                        type: string
+                                      targetName:
+                                        description: The tag name associate with the
+                                          target resource type
+                                        type: string
+                                      targetType:
+                                        description: The target resource type which
+                                          can be Internet Service (gateway) or Nat
+                                          Service (nat-service)
+                                        type: string
+                                    type: object
+                                  type: array
+                                subnets:
+                                  description: The subnet tag name associate with
+                                    a Subnet
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            type: array
+                          securityGroups:
+                            items:
+                              properties:
+                                description:
+                                  description: The description of the security group
+                                  type: string
+                                name:
+                                  description: The tag name associate with the security
+                                    group
+                                  type: string
+                                resourceId:
+                                  description: The Security Group Id response
+                                  type: string
+                                securityGroupRules:
+                                  description: The Security Group Rules configuration
+                                  items:
+                                    properties:
+                                      flow:
+                                        description: The flow of the security group
+                                          (inbound or outbound)
+                                        type: string
+                                      fromPortRange:
+                                        description: The beginning of the port range
+                                        format: int32
+                                        type: integer
+                                      ipProtocol:
+                                        description: The ip protocol name (tcp, udp,
+                                          icmp or -1)
+                                        type: string
+                                      ipRange:
+                                        description: The ip range of the security
+                                          group rule
+                                        type: string
+                                      name:
+                                        description: The tag name associate with the
+                                          security group
+                                        type: string
+                                      resourceId:
+                                        description: The security group rule id
+                                        type: string
+                                      toPortRange:
+                                        description: The end of the port range
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  type: array
+                                tag:
+                                  type: string
+                              type: object
+                            type: array
+                          subnets:
+                            description: The Subnet configuration
+                            items:
+                              properties:
+                                ipSubnetRange:
+                                  description: Subnet Ip range with CIDR notation
+                                  type: string
+                                name:
+                                  description: The tag name associate with the Subnet
+                                  type: string
+                                resourceId:
+                                  description: The Subnet Id response
+                                  type: string
+                                subregionName:
+                                  description: The subregion name of the Subnet
+                                  type: string
+                              type: object
+                            type: array
+                          subregionName:
+                            description: The subregion name
+                            type: string
+                        type: object
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: cluster-api-provider-outscale-system/cluster-api-provider-outscale-serving-cert
+    controller-gen.kubebuilder.io/version: v0.16.5
+  labels:
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1beta1: v1beta1
   name: oscmachines.infrastructure.cluster.x-k8s.io
 spec:
   conversion:

--- a/test/e2e/config/outscale.yaml
+++ b/test/e2e/config/outscale.yaml
@@ -59,6 +59,8 @@ providers:
           - sourcePath: "../../../metadata.yaml"
             targetName: "metadata.yaml"
           - sourcePath: "../data/infrastructure-outscale/cluster-template.yaml"
+          - sourcePath: "../data/infrastructure-outscale/cluster-template-topology.yaml"
+          - sourcePath: "../data/infrastructure-outscale/clusterclass-cluster-class.yaml"
           - sourcePath: "../data/infrastructure-outscale/cluster-template-upgrades.yaml"
           - sourcePath: "../data/infrastructure-outscale/cluster-template-upgrade-scale-in.yaml"
           - sourcePath: "../data/infrastructure-outscale/cluster-template-node-drain.yaml"
@@ -99,11 +101,11 @@ variables:
   KUBETEST_CONFIGURATION: "${KUBETEST_CONF_PATH:=./data/kubetest/conformance.yaml}"
   NODE_DRAIN_TIMEOUT: "60s"
 intervals:
-  default/wait-cluster: ["30m", "10s"]
+  default/wait-cluster: ["15m", "10s"]
   default/wait-control-plane: ["30m", "10s"]
   default/wait-worker-nodes: ["30m", "10s"]
-  default/wait-controllers: ["20m", "10s"]
-  default/wait-delete-cluster: ["30m", "10s"]
+  default/wait-controllers: ["15m", "10s"]
+  default/wait-delete-cluster: ["15m", "10s"]
   default/wait-machine-upgrade: ["30m", "10s"]
   default/wait-machine-status: ["30m", "10s"]
   default/wait-failed-machine-status: ["5m", "10s"]
@@ -113,4 +115,4 @@ intervals:
   default/wait-nodes-ready: ["30m", "10s"]
   default/wait-service: ["5m", "10s"]
   node-drain/wait-deployment-available: ["5m", "10s"]
-  node-drain/wait-machine-deleted: ["30m", "10s"]
+  node-drain/wait-machine-deleted: ["15m", "10s"]

--- a/test/e2e/data/infrastructure-outscale/cluster-template-topology.yaml
+++ b/test/e2e/data/infrastructure-outscale/cluster-template-topology.yaml
@@ -1,0 +1,66 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: "${CLUSTER_NAME}"
+  labels:
+    cni: "${CLUSTER_NAME}-crs-cni"
+    ccm: "${CLUSTER_NAME}-crs-ccm"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: ["10.42.0.0/16"]
+  topology:
+    class: "cluster-class"
+    version: "${KUBERNETES_VERSION}"
+    controlPlane:
+      replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+    variables:
+    - name: subregionName
+      value: eu-west-2a
+    - name: controlPlaneVmType
+      value: tinav6.c4r8p2
+    - name: workerVmType
+      value: tinav6.c4r8p2
+    workers:
+      machineDeployments:
+        - class: "cluster-class-worker"
+          name: "md-0"
+          replicas: ${WORKER_MACHINE_COUNT}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "${CLUSTER_NAME}-crs-ccm"
+data: ${CCM_RESOURCES}
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: "${CLUSTER_NAME}-crs-ccm"
+spec:
+  strategy: ApplyOnce
+  clusterSelector:
+    matchLabels:
+      ccm: "${CLUSTER_NAME}-crs-ccm"
+  resources:
+    - name: "${CLUSTER_NAME}-crs-ccm"
+      kind: ConfigMap
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "${CLUSTER_NAME}-crs-cni"
+data: ${CNI_RESOURCES}
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: "${CLUSTER_NAME}-crs-cni"
+spec:
+  strategy: ApplyOnce
+  clusterSelector:
+    matchLabels:
+      cni: "${CLUSTER_NAME}-crs-cni"
+  resources:
+    - name: "${CLUSTER_NAME}-crs-cni"
+      kind: ConfigMap

--- a/test/e2e/data/infrastructure-outscale/clusterclass-cluster-class.yaml
+++ b/test/e2e/data/infrastructure-outscale/clusterclass-cluster-class.yaml
@@ -1,0 +1,285 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: ClusterClass
+metadata:
+  name: "cluster-class"
+spec:
+  controlPlane:
+    ref:
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+      kind: KubeadmControlPlaneTemplate
+      name: "cluster-class-control-plane"
+    machineInfrastructure:
+      ref:
+        kind: OscMachineTemplate
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        name: "cluster-class-control-plane"
+  infrastructure:
+    ref:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: OscClusterTemplate
+      name: "cluster-class"
+  workers:
+    machineDeployments:
+      - class: cluster-class-worker
+        template:
+          bootstrap:
+            ref:
+              apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+              kind: KubeadmConfigTemplate
+              name: "cluster-class-worker"
+          infrastructure:
+            ref:
+              apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+              kind: OscMachineTemplate
+              name: "cluster-class-worker"
+  variables:
+    - name: subregionName
+      required: true
+      schema:
+        openAPIV3Schema:
+          type: string
+          default: eu-west-2b
+    - name: controlPlaneVmType
+      required: true
+      schema:
+        openAPIV3Schema:
+          type: string
+          default: tinav5.c4r8p2
+    - name: workerVmType
+      required: true
+      schema:
+        openAPIV3Schema:
+          type: string
+          default: tinav5.c4r8p2
+  patches:
+    - name: oscClusterTemplate
+      definitions:
+        - selector:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: OscClusterTemplate
+            matchResources:
+              infrastructureCluster: true
+          jsonPatches:
+            - op: replace
+              path: /spec/template/spec/network/subregionName
+              valueFrom:
+                variable: subregionName
+            - op: replace
+              path: /spec/template/spec/network/clusterName
+              valueFrom:
+                variable: builtin.cluster.name
+            - op: replace
+              path: /spec/template/spec/network/net/clusterName
+              valueFrom:
+                variable: builtin.cluster.name
+            - op: replace
+              path: /spec/template/spec/network/internetService/clusterName
+              valueFrom:
+                variable: builtin.cluster.name
+            - op: replace
+              path: /spec/template/spec/network/loadBalancer/clusterName
+              valueFrom:
+                variable: builtin.cluster.name
+            - op: replace
+              path: /spec/template/spec/network/loadBalancer/loadbalancername
+              valueFrom:
+                variable: builtin.cluster.name
+            - op: replace
+              path: /spec/template/spec/network/natService/clusterName
+              valueFrom:
+                variable: builtin.cluster.name
+            - op: replace
+              path: /spec/template/spec/network/bastion/clusterName
+              valueFrom:
+                variable: builtin.cluster.name
+    - name: OscMachineTemplateControlPlane
+      definitions:
+        - selector:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: OscMachineTemplate
+            matchResources:
+              controlPlane: true
+          jsonPatches:
+            - op: replace
+              path: /spec/template/spec/node/vm/vmType
+              valueFrom:
+                variable: controlPlaneVmType
+            - op: replace
+              path: /spec/template/spec/node/clusterName
+              valueFrom:
+                variable: builtin.cluster.name
+            - op: replace
+              path: /spec/template/spec/node/vm/clusterName
+              valueFrom:
+                variable: builtin.cluster.name
+            - op: replace
+              path: /spec/template/spec/node/vm/loadBalancerName
+              valueFrom:
+                variable: builtin.cluster.name
+            - op: replace
+              path: /spec/template/spec/node/vm/subregionName
+              valueFrom:
+                variable: subregionName
+    - name: OscMachineTemplateControlWorker
+      definitions:
+        - selector:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: OscMachineTemplate
+            matchResources:
+              machineDeploymentClass:
+                names:
+                  - cluster-class-worker
+          jsonPatches:
+            - op: replace
+              path: /spec/template/spec/node/vm/vmType
+              valueFrom:
+                variable: workerVmType
+            - op: replace
+              path: /spec/template/spec/node/clusterName
+              valueFrom:
+                variable: builtin.cluster.name
+            - op: replace
+              path: /spec/template/spec/node/vm/clusterName
+              valueFrom:
+                variable: builtin.cluster.name
+            - op: replace
+              path: /spec/template/spec/node/vm/subregionName
+              valueFrom:
+                variable: subregionName
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OscClusterTemplate
+metadata:
+  name: "cluster-class"
+spec:
+  template:
+    spec:
+      network:
+        clusterName: "REPLACEME"
+        subregionName: "eu-west-2b"
+        loadBalancer:
+          loadbalancername: "REPLACEME"
+          clusterName: "REPLACEME"
+        net:
+          clusterName: "REPLACEME"
+        internetService:
+          clusterName: "REPLACEME"
+        natService:
+          clusterName: "REPLACEME"
+        bastion:
+          clusterName: "REPLACEME"
+          enable: false
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OscMachineTemplate
+metadata:
+  name: "cluster-class-worker"
+spec:
+  template:
+    spec:
+      node:
+        clusterName: "REPLACEME"
+        keypair:
+          name: "${OSC_KEYPAIR_NAME}"
+          deleteKeypair: false
+        vm:
+          clusterName: "REPLACEME"
+          imageId: "${KUBERNETES_IMAGE_UPGRADE_FROM}"
+          rootDisk:
+            rootDiskSize: ${OSC_VOLUME_SIZE}
+            rootDiskIops: ${OSC_IOPS}
+            rootDiskType: "${OSC_VOLUME_TYPE}"
+          keypairName: "${OSC_KEYPAIR_NAME}"
+          subregionName: "eu-west-2b"
+          vmType: "tinav9.c1r1p1"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OscMachineTemplate
+metadata:
+  name: "cluster-class-control-plane"
+spec:
+  template:
+    spec:
+      node:
+        clusterName: "REPLACEME"
+        keypair:
+          name: "${OSC_KEYPAIR_NAME}"
+          deleteKeypair: false
+        vm:
+          clusterName: "REPLACEME"
+          imageId: "${KUBERNETES_IMAGE_UPGRADE_FROM}"
+          rootDisk:
+            rootDiskSize: ${OSC_VOLUME_SIZE}
+            rootDiskIops: ${OSC_IOPS}
+            rootDiskType: "${OSC_VOLUME_TYPE}"
+          subregionName: "eu-west-2b"
+          keypairName: "${OSC_KEYPAIR_NAME}"
+          role: controlplane
+          loadBalancerName: "REPLACEME"
+          vmType: "tinav9.c1r1p1"
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: "cluster-class-worker"
+spec:
+  template:
+    spec:
+      files:
+        - content: |
+            #!/bin/sh
+
+            curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
+            chmod +x /tmp/runc.amd64
+            cp -f /tmp/runc.amd64 /usr/local/sbin/runc
+          owner: root:root
+          path: /tmp/set_runc.sh
+          permissions: "0744"
+      joinConfiguration:
+        nodeRegistration:
+          name: "{{ ds.meta_data.local_hostname }}"
+          kubeletExtraArgs:
+            cloud-provider: external
+            provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
+      preKubeadmCommands:
+        - sh /tmp/set_runc.sh
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlaneTemplate
+metadata:
+  name: "cluster-class-control-plane"
+spec:
+  template:
+    spec:
+      kubeadmConfigSpec:
+        clusterConfiguration:
+          apiServer:
+            extraArgs:
+              cloud-provider: external
+          controllerManager:
+            extraArgs:
+              cloud-provider: external
+        initConfiguration:
+          nodeRegistration:
+            name: '{{ ds.meta_data.local_hostname }}'
+            kubeletExtraArgs:
+              cloud-provider: external
+              provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
+        files:
+          - content: |
+              #!/bin/sh
+
+              curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
+              chmod +x /tmp/runc.amd64
+              cp -f /tmp/runc.amd64 /usr/local/sbin/runc
+            owner: root:root
+            path: /tmp/set_runc.sh
+            permissions: "0744"
+        joinConfiguration:
+          nodeRegistration:
+            name: "{{ ds.meta_data.local_hostname }}"
+            kubeletExtraArgs:
+              cloud-provider: external
+              provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
+        preKubeadmCommands:
+          - sh /tmp/set_runc.sh

--- a/test/e2e/data/infrastructure-outscale/infrastructure-components.yaml
+++ b/test/e2e/data/infrastructure-outscale/infrastructure-components.yaml
@@ -412,6 +412,485 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  labels:
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: oscclustertemplates.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: OscClusterTemplate
+    listKind: OscClusterTemplateList
+    plural: oscclustertemplates
+    singular: oscclustertemplate
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: OscClusterTemplate is the Schema for the oscclustertemplates
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OscClusterTemplateSpec defines the desired state of OscClusterTemplate
+            properties:
+              template:
+                properties:
+                  metadata:
+                    description: |-
+                      ObjectMeta is metadata that all persisted resources must have, which includes all objects
+                      users must create. This is a copy of customizable fields from metav1.ObjectMeta.
+
+                      ObjectMeta is embedded in `Machine.Spec`, `MachineDeployment.Template` and `MachineSet.Template`,
+                      which are not top-level Kubernetes objects. Given that metav1.ObjectMeta has lots of special cases
+                      and read-only fields which end up in the generated CRD validation, having it as a subset simplifies
+                      the API and some issues that can impact user experience.
+
+                      During the [upgrade to controller-tools@v2](https://github.com/kubernetes-sigs/cluster-api/pull/1054)
+                      for v1alpha2, we noticed a failure would occur running Cluster API test suite against the new CRDs,
+                      specifically `spec.metadata.creationTimestamp in body must be of type string: "null"`.
+                      The investigation showed that `controller-tools@v2` behaves differently than its previous version
+                      when handling types from [metav1](k8s.io/apimachinery/pkg/apis/meta/v1) package.
+
+                      In more details, we found that embedded (non-top level) types that embedded `metav1.ObjectMeta`
+                      had validation properties, including for `creationTimestamp` (metav1.Time).
+                      The `metav1.Time` type specifies a custom json marshaller that, when IsZero() is true, returns `null`
+                      which breaks validation because the field isn't marked as nullable.
+
+                      In future versions, controller-tools@v2 might allow overriding the type and validation for embedded
+                      types. When that happens, this hack should be revisited.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: OscClusterSpec defines the desired state of OscCluster
+                    properties:
+                      controlPlaneEndpoint:
+                        description: APIEndpoint represents a reachable Kubernetes
+                          API endpoint.
+                        properties:
+                          host:
+                            description: The hostname on which the API server is serving.
+                            type: string
+                          port:
+                            description: The port on which the API server is serving.
+                            format: int32
+                            type: integer
+                        required:
+                        - host
+                        - port
+                        type: object
+                      network:
+                        properties:
+                          bastion:
+                            description: The bastion configuration
+                            properties:
+                              clusterName:
+                                type: string
+                              deviceName:
+                                type: string
+                              enable:
+                                type: boolean
+                              imageAccountId:
+                                type: string
+                              imageId:
+                                type: string
+                              imageName:
+                                type: string
+                              keypairName:
+                                type: string
+                              name:
+                                type: string
+                              privateIps:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    privateIp:
+                                      type: string
+                                  type: object
+                                type: array
+                              publicIpName:
+                                type: string
+                              resourceId:
+                                type: string
+                              rootDisk:
+                                properties:
+                                  rootDiskIops:
+                                    format: int32
+                                    type: integer
+                                  rootDiskSize:
+                                    format: int32
+                                    type: integer
+                                  rootDiskType:
+                                    type: string
+                                type: object
+                              securityGroupNames:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                type: array
+                              subnetName:
+                                type: string
+                              subregionName:
+                                type: string
+                              vmType:
+                                type: string
+                            type: object
+                          clusterName:
+                            description: The name of the cluster
+                            type: string
+                          controlPlaneSubnets:
+                            description: List of subnet to spread controlPlane nodes
+                            items:
+                              type: string
+                            type: array
+                          extraSecurityGroupRule:
+                            description: Add SecurityGroup Rule after the cluster
+                              is created
+                            type: boolean
+                          image:
+                            description: The image configuration
+                            properties:
+                              accountId:
+                                type: string
+                              name:
+                                type: string
+                              resourceId:
+                                type: string
+                            type: object
+                          internetService:
+                            description: The Internet Service configuration
+                            properties:
+                              clusterName:
+                                description: the name of the cluster
+                                type: string
+                              name:
+                                description: The tag name associate with the Subnet
+                                type: string
+                              resourceId:
+                                description: the Internet Service response
+                                type: string
+                            type: object
+                          loadBalancer:
+                            description: The Load Balancer configuration
+                            properties:
+                              clusterName:
+                                type: string
+                              healthCheck:
+                                description: The healthCheck configuration  of the
+                                  Load Balancer
+                                properties:
+                                  checkinterval:
+                                    description: the time in second between two pings
+                                    format: int32
+                                    type: integer
+                                  healthythreshold:
+                                    description: the consecutive number of pings which
+                                      are successful to consider the vm healthy
+                                    format: int32
+                                    type: integer
+                                  port:
+                                    description: the HealthCheck port number
+                                    format: int32
+                                    type: integer
+                                  protocol:
+                                    description: The HealthCheck protocol ('HTTP'|'TCP')
+                                    type: string
+                                  timeout:
+                                    description: the Timeout to consider VM unhealthy
+                                    format: int32
+                                    type: integer
+                                  unhealthythreshold:
+                                    description: the consecutive number of pings which
+                                      are failed to consider the vm unhealthy
+                                    format: int32
+                                    type: integer
+                                type: object
+                              listener:
+                                description: The Listener cofiguration of the loadBalancer
+                                properties:
+                                  backendport:
+                                    description: The port on which the backend vm
+                                      will listen
+                                    format: int32
+                                    type: integer
+                                  backendprotocol:
+                                    description: The protocol ('HTTP'|'TCP') to route
+                                      the traffic to the backend vm
+                                    type: string
+                                  loadbalancerport:
+                                    description: The port on which the loadbalancer
+                                      will listen
+                                    format: int32
+                                    type: integer
+                                  loadbalancerprotocol:
+                                    description: the routing protocol ('HTTP'|'TCP')
+                                    type: string
+                                type: object
+                              loadbalancername:
+                                description: The Load Balancer unique name
+                                type: string
+                              loadbalancertype:
+                                description: The Load Balancer Type internet-facing
+                                  or internal
+                                type: string
+                              securitygroupname:
+                                description: The security group tag name associate
+                                  with a security group
+                                type: string
+                              subnetname:
+                                description: The subnet tag name associate with a
+                                  Subnet
+                                type: string
+                            type: object
+                          natService:
+                            description: The Nat Service configuration
+                            properties:
+                              clusterName:
+                                description: The name of the cluster
+                                type: string
+                              name:
+                                description: The tag name associate with the Nat Service
+                                type: string
+                              publicipname:
+                                description: The Public Ip tag name associated with
+                                  a Public Ip
+                                type: string
+                              resourceId:
+                                description: The Nat Service Id response
+                                type: string
+                              subnetname:
+                                description: The subnet tag name associate with a
+                                  Subnet
+                                type: string
+                            type: object
+                          natServices:
+                            description: The Nat Services configuration
+                            items:
+                              properties:
+                                clusterName:
+                                  description: The name of the cluster
+                                  type: string
+                                name:
+                                  description: The tag name associate with the Nat
+                                    Service
+                                  type: string
+                                publicipname:
+                                  description: The Public Ip tag name associated with
+                                    a Public Ip
+                                  type: string
+                                resourceId:
+                                  description: The Nat Service Id response
+                                  type: string
+                                subnetname:
+                                  description: The subnet tag name associate with
+                                    a Subnet
+                                  type: string
+                              type: object
+                            type: array
+                          net:
+                            description: The Net configuration
+                            properties:
+                              clusterName:
+                                description: the name of the cluster
+                                type: string
+                              ipRange:
+                                description: the net ip range with CIDR notation
+                                type: string
+                              name:
+                                description: the tag name associate with the Net
+                                type: string
+                              resourceId:
+                                description: The Net Id response
+                                type: string
+                            type: object
+                          publicIps:
+                            description: The Public Ip configuration
+                            items:
+                              properties:
+                                clusterName:
+                                  type: string
+                                name:
+                                  description: The tag name associate with the Public
+                                    Ip
+                                  type: string
+                                resourceId:
+                                  description: The Public Ip Id response
+                                  type: string
+                              type: object
+                            type: array
+                          routeTables:
+                            description: The Route Table configuration
+                            items:
+                              properties:
+                                name:
+                                  description: The tag name associate with the Route
+                                    Table
+                                  type: string
+                                resourceId:
+                                  description: The Route Table Id response
+                                  type: string
+                                routes:
+                                  description: The Route configuration
+                                  items:
+                                    properties:
+                                      destination:
+                                        description: the destination match Ip range
+                                          with CIDR notation
+                                        type: string
+                                      name:
+                                        description: The tag name associate with the
+                                          Route
+                                        type: string
+                                      resourceId:
+                                        description: The Route Id response
+                                        type: string
+                                      targetName:
+                                        description: The tag name associate with the
+                                          target resource type
+                                        type: string
+                                      targetType:
+                                        description: The target resource type which
+                                          can be Internet Service (gateway) or Nat
+                                          Service (nat-service)
+                                        type: string
+                                    type: object
+                                  type: array
+                                subnets:
+                                  description: The subnet tag name associate with
+                                    a Subnet
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            type: array
+                          securityGroups:
+                            items:
+                              properties:
+                                description:
+                                  description: The description of the security group
+                                  type: string
+                                name:
+                                  description: The tag name associate with the security
+                                    group
+                                  type: string
+                                resourceId:
+                                  description: The Security Group Id response
+                                  type: string
+                                securityGroupRules:
+                                  description: The Security Group Rules configuration
+                                  items:
+                                    properties:
+                                      flow:
+                                        description: The flow of the security group
+                                          (inbound or outbound)
+                                        type: string
+                                      fromPortRange:
+                                        description: The beginning of the port range
+                                        format: int32
+                                        type: integer
+                                      ipProtocol:
+                                        description: The ip protocol name (tcp, udp,
+                                          icmp or -1)
+                                        type: string
+                                      ipRange:
+                                        description: The ip range of the security
+                                          group rule
+                                        type: string
+                                      name:
+                                        description: The tag name associate with the
+                                          security group
+                                        type: string
+                                      resourceId:
+                                        description: The security group rule id
+                                        type: string
+                                      toPortRange:
+                                        description: The end of the port range
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  type: array
+                                tag:
+                                  type: string
+                              type: object
+                            type: array
+                          subnets:
+                            description: The Subnet configuration
+                            items:
+                              properties:
+                                ipSubnetRange:
+                                  description: Subnet Ip range with CIDR notation
+                                  type: string
+                                name:
+                                  description: The tag name associate with the Subnet
+                                  type: string
+                                resourceId:
+                                  description: The Subnet Id response
+                                  type: string
+                                subregionName:
+                                  description: The subregion name of the Subnet
+                                  type: string
+                              type: object
+                            type: array
+                          subregionName:
+                            description: The subregion name
+                            type: string
+                        type: object
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   labels:

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 )
 
-var _ = Describe("[e2e] Running the Cluster API E2E tests", func() {
+var _ = Describe("[e2e][all] Running the Cluster API E2E tests", func() {
 	var (
 		ctx           = context.TODO()
 		specName      = "e2e"

--- a/test/e2e/node_test.go
+++ b/test/e2e/node_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 var _ = Describe("Node drain", func() {
-	Context("[node-drain] Run node drain test", func() {
+	Context("[node-drain][all] Run node drain test", func() {
 		capi_e2e.NodeDrainTimeoutSpec(context.TODO(), func() capi_e2e.NodeDrainTimeoutSpecInput {
 			return capi_e2e.NodeDrainTimeoutSpecInput{
 				E2EConfig:              e2eConfig,

--- a/test/e2e/quickstart_test.go
+++ b/test/e2e/quickstart_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
 
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 )
@@ -30,6 +31,20 @@ var _ = Describe("[quickstart][fast] Running the Cluster API quick start tests",
 				BootstrapClusterProxy:  bootstrapClusterProxy,
 				ArtifactFolder:         artifactFolder,
 				SkipCleanup:            skipCleanup,
+			}
+		})
+	})
+
+	Context("Running the quick-start topology spec", func() {
+		capi_e2e.QuickStartSpec(ctx, func() capi_e2e.QuickStartSpecInput {
+			return capi_e2e.QuickStartSpecInput{
+				E2EConfig:              e2eConfig,
+				ClusterctlConfigPath:   clusterctlConfigPath,
+				InfrastructureProvider: &infraProvider,
+				BootstrapClusterProxy:  bootstrapClusterProxy,
+				ArtifactFolder:         artifactFolder,
+				SkipCleanup:            skipCleanup,
+				Flavor:                 ptr.To("topology"),
 			}
 		})
 	})


### PR DESCRIPTION
* Enable OscClusterTemplate CRD
* Add cluster class e2e test

Be aware that ClusterClass is behind the ClusterTopology feature gate, which might need activation on capi-kubeadm-control-plane-controller-manager and capi-controller-manager