### PR TITLE
🥅 errors: better error messages from Outscale API

### DIFF
--- a/cloud/services/compute/image.go
+++ b/cloud/services/compute/image.go
@@ -50,7 +50,7 @@ func (s *Service) GetImage(ctx context.Context, imageId string) (*osc.Image, err
 		utils.LogAPICall(ctx, "ReadImages", readImageRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", readImageRequest)
 			if reconciler.KeepRetryWithError(
@@ -91,7 +91,7 @@ func (s *Service) GetImageId(ctx context.Context, imageName string) (string, err
 		utils.LogAPICall(ctx, "ReadImages", readImageRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", readImageRequest)
 			if reconciler.KeepRetryWithError(
@@ -132,7 +132,7 @@ func (s *Service) GetImageName(ctx context.Context, imageId string) (string, err
 		utils.LogAPICall(ctx, "ReadImages", readImageRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", readImageRequest)
 			if reconciler.KeepRetryWithError(

--- a/cloud/services/compute/vm.go
+++ b/cloud/services/compute/vm.go
@@ -113,7 +113,7 @@ func (s *Service) CreateVm(ctx context.Context, machineScope *scope.MachineScope
 		utils.LogAPICall(ctx, "CreateVms", vmOpt, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", vmOpt)
 			if reconciler.KeepRetryWithError(
@@ -148,7 +148,7 @@ func (s *Service) CreateVm(ctx context.Context, machineScope *scope.MachineScope
 	err, httpRes := tag.AddTag(ctx, vmTagRequest, resourceIds, oscApiClient, oscAuthClient)
 	if err != nil {
 		if httpRes != nil {
-			return nil, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+			return nil, utils.ExtractOAPIError(err, httpRes)
 		} else {
 			return nil, err
 		}
@@ -228,7 +228,7 @@ func (s *Service) CreateVmUserData(ctx context.Context, userData string, spec *i
 	err, httpRes = tag.AddTag(ctx, vmTagRequest, resourceIds, oscApiClient, oscAuthClient)
 	if err != nil {
 		if httpRes != nil {
-			return nil, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+			return nil, utils.ExtractOAPIError(err, httpRes)
 		} else {
 			return nil, err
 		}
@@ -253,7 +253,7 @@ func (s *Service) DeleteVm(ctx context.Context, vmId string) error {
 		utils.LogAPICall(ctx, "DeleteVms", deleteVmsRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", deleteVmsRequest)
 			if reconciler.KeepRetryWithError(
@@ -291,7 +291,7 @@ func (s *Service) GetVm(ctx context.Context, vmId string) (*osc.Vm, error) {
 		utils.LogAPICall(ctx, "ReadVmsRequest", readVmsRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", readVmsRequest)
 			if reconciler.KeepRetryWithError(
@@ -340,7 +340,7 @@ func (s *Service) GetVmListFromTag(ctx context.Context, tagKey string, tagValue 
 		utils.LogAPICall(ctx, "ReadVms", readVmsRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", readVmsRequest)
 			if reconciler.KeepRetryWithError(

--- a/cloud/services/net/internetservice.go
+++ b/cloud/services/net/internetservice.go
@@ -51,7 +51,7 @@ func (s *Service) CreateInternetService(ctx context.Context, internetServiceName
 		utils.LogAPICall(ctx, "CreateInternetService", internetServiceRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", internetServiceRequest)
 			if reconciler.KeepRetryWithError(
@@ -81,7 +81,7 @@ func (s *Service) CreateInternetService(ctx context.Context, internetServiceName
 	err, httpRes := tag.AddTag(ctx, internetServiceTagRequest, resourceIds, oscApiClient, oscAuthClient)
 	if err != nil {
 		if httpRes != nil {
-			return nil, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+			return nil, utils.ExtractOAPIError(err, httpRes)
 		} else {
 			return nil, err
 		}
@@ -105,7 +105,7 @@ func (s *Service) DeleteInternetService(ctx context.Context, internetServiceId s
 		utils.LogAPICall(ctx, "DeleteInternetService", deleteInternetServiceRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", deleteInternetServiceRequest)
 			if reconciler.KeepRetryWithError(
@@ -141,7 +141,7 @@ func (s *Service) LinkInternetService(ctx context.Context, internetServiceId str
 		utils.LogAPICall(ctx, "LinkInternetService", linkInternetServiceRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", linkInternetServiceRequest)
 			if reconciler.KeepRetryWithError(
@@ -177,7 +177,7 @@ func (s *Service) UnlinkInternetService(ctx context.Context, internetServiceId s
 		utils.LogAPICall(ctx, "UnlinkInternetService", unlinkInternetServiceRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", unlinkInternetServiceRequest)
 			if reconciler.KeepRetryWithError(
@@ -215,7 +215,7 @@ func (s *Service) GetInternetService(ctx context.Context, internetServiceId stri
 		utils.LogAPICall(ctx, "ReadInternetServices", readInternetServiceRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", readInternetServiceRequest)
 			if reconciler.KeepRetryWithError(

--- a/cloud/services/net/natservice.go
+++ b/cloud/services/net/natservice.go
@@ -84,7 +84,7 @@ func (s *Service) CreateNatService(ctx context.Context, publicIpId string, subne
 	err, httpRes := tag.AddTag(ctx, natServiceTagRequest, resourceIds, oscApiClient, oscAuthClient)
 	if err != nil {
 		if httpRes != nil {
-			return nil, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+			return nil, utils.ExtractOAPIError(err, httpRes)
 		} else {
 			return nil, err
 		}
@@ -92,7 +92,7 @@ func (s *Service) CreateNatService(ctx context.Context, publicIpId string, subne
 	subnet, err := s.GetSubnet(ctx, subnetId)
 	if err != nil {
 		if httpRes != nil {
-			return nil, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+			return nil, utils.ExtractOAPIError(err, httpRes)
 		} else {
 			return nil, err
 		}
@@ -109,7 +109,7 @@ func (s *Service) CreateNatService(ctx context.Context, publicIpId string, subne
 	err, httpRes = tag.AddTag(ctx, natServiceClusterTagRequest, resourceIds, oscApiClient, oscAuthClient)
 	if err != nil {
 		if httpRes != nil {
-			return nil, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+			return nil, utils.ExtractOAPIError(err, httpRes)
 		} else {
 			return nil, err
 		}
@@ -134,7 +134,7 @@ func (s *Service) DeleteNatService(ctx context.Context, natServiceId string) err
 		utils.LogAPICall(ctx, "DeleteNatService", deleteNatServiceRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", deleteNatServiceRequest)
 			if reconciler.KeepRetryWithError(
@@ -168,7 +168,7 @@ func (s *Service) GetNatService(ctx context.Context, natServiceId string) (*osc.
 	utils.LogAPICall(ctx, "ReadNatServices", readNatServicesRequest, httpRes, err)
 	if err != nil {
 		if httpRes != nil {
-			return nil, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+			return nil, utils.ExtractOAPIError(err, httpRes)
 		} else {
 			return nil, err
 		}

--- a/cloud/services/net/net.go
+++ b/cloud/services/net/net.go
@@ -54,7 +54,7 @@ func (s *Service) CreateNet(ctx context.Context, spec *infrastructurev1beta1.Osc
 	utils.LogAPICall(ctx, "CreateNet", netRequest, httpRes, err)
 	if err != nil {
 		if httpRes != nil {
-			return nil, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+			return nil, utils.ExtractOAPIError(err, httpRes)
 		}
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func (s *Service) CreateNet(ctx context.Context, spec *infrastructurev1beta1.Osc
 	err, httpRes = tag.AddTag(ctx, netTagRequest, resourceIds, oscApiClient, oscAuthClient)
 	if err != nil {
 		if httpRes != nil {
-			return nil, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+			return nil, utils.ExtractOAPIError(err, httpRes)
 		} else {
 			return nil, err
 		}
@@ -109,7 +109,7 @@ func (s *Service) DeleteNet(ctx context.Context, netId string) error {
 		utils.LogAPICall(ctx, "DeleteNet", deleteNetRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", deleteNetRequest)
 			if reconciler.KeepRetryWithError(
@@ -144,7 +144,7 @@ func (s *Service) GetNet(ctx context.Context, netId string) (*osc.Net, error) {
 	if err != nil {
 		if httpRes != nil {
 			fmt.Printf("Error with http result %s", httpRes.Status)
-			return nil, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+			return nil, utils.ExtractOAPIError(err, httpRes)
 		} else {
 			return nil, err
 		}

--- a/cloud/services/net/subnet.go
+++ b/cloud/services/net/subnet.go
@@ -63,7 +63,7 @@ func (s *Service) CreateSubnet(ctx context.Context, spec *infrastructurev1beta1.
 		utils.LogAPICall(ctx, "CreateSubnet", subnetRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", subnetRequest)
 			if reconciler.KeepRetryWithError(
@@ -94,7 +94,7 @@ func (s *Service) CreateSubnet(ctx context.Context, spec *infrastructurev1beta1.
 	err, httpRes := tag.AddTag(ctx, subnetTagRequest, resourceIds, oscApiClient, oscAuthClient)
 	if err != nil {
 		if httpRes != nil {
-			return nil, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+			return nil, utils.ExtractOAPIError(err, httpRes)
 		} else {
 			return nil, err
 		}
@@ -110,7 +110,7 @@ func (s *Service) CreateSubnet(ctx context.Context, spec *infrastructurev1beta1.
 	err, httpRes = tag.AddTag(ctx, subnetClusterTagRequest, resourceIds, oscApiClient, oscAuthClient)
 	if err != nil {
 		if httpRes != nil {
-			return nil, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+			return nil, utils.ExtractOAPIError(err, httpRes)
 		} else {
 			return nil, err
 		}
@@ -136,7 +136,7 @@ func (s *Service) DeleteSubnet(ctx context.Context, subnetId string) error {
 		utils.LogAPICall(ctx, "DeleteSubnet", deleteSubnetRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 
 			requestStr := fmt.Sprintf("%v", deleteSubnetRequest)
@@ -205,7 +205,7 @@ func (s *Service) GetSubnetIdsFromNetIds(ctx context.Context, netId string) ([]s
 		utils.LogAPICall(ctx, "ReadSubnets", readSubnetsRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", readSubnetsRequest)
 			if reconciler.KeepRetryWithError(

--- a/cloud/services/security/keypair.go
+++ b/cloud/services/security/keypair.go
@@ -51,7 +51,7 @@ func (s *Service) CreateKeyPair(ctx context.Context, keypairName string) (*osc.K
 		utils.LogAPICall(ctx, "CreateKeypair", keyPairRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", keyPairRequest)
 			if reconciler.KeepRetryWithError(
@@ -108,7 +108,7 @@ func (s *Service) GetKeyPair(ctx context.Context, keyPairName string) (*osc.Keyp
 		utils.LogAPICall(ctx, "ReadKeypairs", readKeypairsRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", readKeypairsRequest)
 			if reconciler.KeepRetryWithError(
@@ -151,7 +151,7 @@ func (s *Service) DeleteKeyPair(ctx context.Context, keyPairName string) error {
 		utils.LogAPICall(ctx, "DeleteKeypair", deleteKeypairRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", deleteKeypairRequest)
 			if reconciler.KeepRetryWithError(

--- a/cloud/services/security/publicip.go
+++ b/cloud/services/security/publicip.go
@@ -56,7 +56,7 @@ func (s *Service) CreatePublicIp(ctx context.Context, publicIpName string) (*osc
 		utils.LogAPICall(ctx, "CreatePublicIp", publicIpRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", publicIpRequest)
 			if reconciler.KeepRetryWithError(
@@ -110,7 +110,7 @@ func (s *Service) DeletePublicIp(ctx context.Context, publicIpId string) error {
 		utils.LogAPICall(ctx, "DeletePublicIp", deletePublicIpRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", deletePublicIpRequest)
 			if reconciler.KeepRetryWithError(
@@ -149,7 +149,7 @@ func (s *Service) GetPublicIp(ctx context.Context, publicIpId string) (*osc.Publ
 		utils.LogAPICall(ctx, "ReadPublicIps", readPublicIpRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", readPublicIpRequest)
 			if reconciler.KeepRetryWithError(
@@ -196,7 +196,7 @@ func (s *Service) ValidatePublicIpIds(ctx context.Context, publicIpIds []string)
 		utils.LogAPICall(ctx, "ReadPublicIps", readPublicIpRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", readPublicIpRequest)
 			if reconciler.KeepRetryWithError(
@@ -244,7 +244,7 @@ func (s *Service) LinkPublicIp(ctx context.Context, publicIpId string, vmId stri
 		utils.LogAPICall(ctx, "LinkPublicIp", linkPublicIpRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", linkPublicIpRequest)
 			if reconciler.KeepRetryWithError(
@@ -283,7 +283,7 @@ func (s *Service) UnlinkPublicIp(ctx context.Context, linkPublicIpId string) err
 		utils.LogAPICall(ctx, "UnlinkPublicIp", unlinkPublicIpRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", unlinkPublicIpRequest)
 			if reconciler.KeepRetryWithError(

--- a/cloud/services/security/route.go
+++ b/cloud/services/security/route.go
@@ -58,7 +58,7 @@ func (s *Service) CreateRouteTable(ctx context.Context, netId string, clusterNam
 		utils.LogAPICall(ctx, "CreateRouteTable", routeTableRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", routeTableRequest)
 			if reconciler.KeepRetryWithError(
@@ -88,7 +88,7 @@ func (s *Service) CreateRouteTable(ctx context.Context, netId string, clusterNam
 	err, httpRes := tag.AddTag(ctx, routeTableTagRequest, resourceIds, oscApiClient, oscAuthClient)
 	if err != nil {
 		if httpRes != nil {
-			return nil, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+			return nil, utils.ExtractOAPIError(err, httpRes)
 		} else {
 			return nil, err
 		}
@@ -104,7 +104,7 @@ func (s *Service) CreateRouteTable(ctx context.Context, netId string, clusterNam
 	err, httpRes = tag.AddTag(ctx, clusterRouteTagRequest, resourceIds, oscApiClient, oscAuthClient)
 	if err != nil {
 		if httpRes != nil {
-			return nil, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+			return nil, utils.ExtractOAPIError(err, httpRes)
 		} else {
 			return nil, err
 		}
@@ -147,7 +147,7 @@ func (s *Service) CreateRoute(ctx context.Context, destinationIpRange string, ro
 	utils.LogAPICall(ctx, "CreateRoute", routeRequest, httpRes, err)
 	if err != nil {
 		if httpRes != nil {
-			return nil, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+			return nil, utils.ExtractOAPIError(err, httpRes)
 		} else {
 			return nil, err
 		}
@@ -171,7 +171,7 @@ func (s *Service) DeleteRouteTable(ctx context.Context, routeTableId string) err
 		utils.LogAPICall(ctx, "DeleteRouteTable", deleteRouteTableRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", deleteRouteTableRequest)
 			if reconciler.KeepRetryWithError(
@@ -207,7 +207,7 @@ func (s *Service) DeleteRoute(ctx context.Context, destinationIpRange string, ro
 		utils.LogAPICall(ctx, "DeleteRoute", deleteRouteRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", deleteRouteRequest)
 			if reconciler.KeepRetryWithError(
@@ -241,7 +241,7 @@ func (s *Service) GetRouteTable(ctx context.Context, routeTableId []string) (*os
 	utils.LogAPICall(ctx, "ReadRouteTables", readRouteTableRequest, httpRes, err)
 	if err != nil {
 		if httpRes != nil {
-			return nil, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+			return nil, utils.ExtractOAPIError(err, httpRes)
 		} else {
 			return nil, err
 		}
@@ -286,7 +286,7 @@ func (s *Service) GetRouteTableFromRoute(ctx context.Context, routeTableId strin
 	utils.LogAPICall(ctx, "ReadRouteTables", readRouteRequest, httpRes, err)
 	if err != nil {
 		if httpRes != nil {
-			return nil, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+			return nil, utils.ExtractOAPIError(err, httpRes)
 		} else {
 			return nil, err
 		}
@@ -319,7 +319,7 @@ func (s *Service) LinkRouteTable(ctx context.Context, routeTableId string, subne
 		utils.LogAPICall(ctx, "LinkRouteTable", linkRouteTableRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", linkRouteTableRequest)
 			if reconciler.KeepRetryWithError(
@@ -359,7 +359,7 @@ func (s *Service) UnlinkRouteTable(ctx context.Context, linkRouteTableId string)
 		utils.LogAPICall(ctx, "UnlinkRouteTable", unlinkRouteTableRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", unlinkRouteTableRequest)
 			if reconciler.KeepRetryWithError(
@@ -393,7 +393,7 @@ func (s *Service) GetRouteTableIdsFromNetIds(ctx context.Context, netId string) 
 	utils.LogAPICall(ctx, "ReadRouteTables", readRouteTablesRequest, httpRes, err)
 	if err != nil {
 		if httpRes != nil {
-			return nil, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+			return nil, utils.ExtractOAPIError(err, httpRes)
 		} else {
 			return nil, err
 		}

--- a/cloud/services/security/securitygroup.go
+++ b/cloud/services/security/securitygroup.go
@@ -95,7 +95,7 @@ func (s *Service) CreateSecurityGroup(ctx context.Context, netId string, cluster
 	err, httpRes := tag.AddTag(ctx, clusterSecurityGroupRequest, resourceIds, oscApiClient, oscAuthClient)
 	if err != nil {
 		if httpRes != nil {
-			return nil, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+			return nil, utils.ExtractOAPIError(err, httpRes)
 		} else {
 			return nil, err
 		}
@@ -112,7 +112,7 @@ func (s *Service) CreateSecurityGroup(ctx context.Context, netId string, cluster
 		err, httpRes := tag.AddTag(ctx, mainSecurityGroupTagRequest, resourceIds, oscApiClient, oscAuthClient)
 		if err != nil {
 			if httpRes != nil {
-				return nil, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return nil, utils.ExtractOAPIError(err, httpRes)
 			} else {
 				return nil, err
 			}
@@ -164,7 +164,7 @@ func (s *Service) CreateSecurityGroupRule(ctx context.Context, securityGroupId s
 				if httpRes.StatusCode == 409 {
 					return true, nil
 				}
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", createSecurityGroupRuleRequest)
 			if reconciler.KeepRetryWithError(
@@ -229,7 +229,7 @@ func (s *Service) DeleteSecurityGroupRule(ctx context.Context, securityGroupId s
 		utils.LogAPICall(ctx, "DeleteSecurityGroupRule", deleteSecurityGroupRuleRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", deleteSecurityGroupRuleRequest)
 			if reconciler.KeepRetryWithError(
@@ -286,7 +286,7 @@ func (s *Service) GetSecurityGroup(ctx context.Context, securityGroupId string) 
 		utils.LogAPICall(ctx, "ReadSecurityGroups", readSecurityGroupRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", readSecurityGroupRequest)
 			if reconciler.KeepRetryWithError(
@@ -371,7 +371,7 @@ func (s *Service) SecurityGroupHasRule(ctx context.Context, securityGroupId stri
 		utils.LogAPICall(ctx, "ReadSecurityGroups", readSecurityGroupRuleRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", readSecurityGroupRuleRequest)
 			if reconciler.KeepRetryWithError(
@@ -413,7 +413,7 @@ func (s *Service) GetSecurityGroupIdsFromNetIds(ctx context.Context, netId strin
 		utils.LogAPICall(ctx, "ReadSecurityGroups", readSecurityGroupRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", readSecurityGroupRequest)
 			if reconciler.KeepRetryWithError(

--- a/cloud/services/service/load_balancer.go
+++ b/cloud/services/service/load_balancer.go
@@ -109,7 +109,7 @@ func (s *Service) ConfigureHealthCheck(ctx context.Context, spec *infrastructure
 		utils.LogAPICall(ctx, "UpdateLoadBalancer", updateLoadBalancerRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", updateLoadBalancerRequest)
 			if reconciler.KeepRetryWithError(
@@ -149,7 +149,7 @@ func (s *Service) LinkLoadBalancerBackendMachines(ctx context.Context, vmIds []s
 		utils.LogAPICall(ctx, "LinkLoadBalancerBackendMachines", linkLoadBalancerBackendMachinesRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", linkLoadBalancerBackendMachinesRequest)
 			if reconciler.KeepRetryWithError(
@@ -186,7 +186,7 @@ func (s *Service) UnlinkLoadBalancerBackendMachines(ctx context.Context, vmIds [
 		utils.LogAPICall(ctx, "UnlinkLoadBalancerBackendMachines", unlinkLoadBalancerBackendMachinesRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", unlinkLoadBalancerBackendMachinesRequest)
 			if reconciler.KeepRetryWithError(
@@ -231,7 +231,7 @@ func (s *Service) GetLoadBalancer(ctx context.Context, loadBalancerName string) 
 					reconciler.ThrottlingErrors) {
 					return false, nil
 				} else {
-					return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+					return false, utils.ExtractOAPIError(err, httpRes)
 				}
 			}
 			return false, err
@@ -275,7 +275,7 @@ func (s *Service) GetLoadBalancerTag(ctx context.Context, spec *infrastructurev1
 		utils.LogAPICall(ctx, "ReadLoadBalancerTags", readLoadBalancerTagRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", readLoadBalancerTagRequest)
 			if reconciler.KeepRetryWithError(
@@ -385,7 +385,7 @@ func (s *Service) CreateLoadBalancer(ctx context.Context, spec *infrastructurev1
 		utils.LogAPICall(ctx, "CreateLoadBalancer", loadBalancerRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", loadBalancerRequest)
 			if reconciler.KeepRetryWithError(
@@ -428,7 +428,7 @@ func (s *Service) DeleteLoadBalancer(ctx context.Context, spec *infrastructurev1
 		utils.LogAPICall(ctx, "DeleteLoadBalancer", deleteLoadBalancerRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", deleteLoadBalancerRequest)
 			if reconciler.KeepRetryWithError(
@@ -468,7 +468,7 @@ func (s *Service) DeleteLoadBalancerTag(ctx context.Context, spec *infrastructur
 		utils.LogAPICall(ctx, "DeleteLoadBalancerTags", deleteLoadBalancerTagRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", deleteLoadBalancerTagRequest)
 			if reconciler.KeepRetryWithError(

--- a/cloud/services/storage/volume.go
+++ b/cloud/services/storage/volume.go
@@ -67,7 +67,7 @@ func (s *Service) CreateVolume(ctx context.Context, spec *infrastructurev1beta1.
 		utils.LogAPICall(ctx, "CreateVolume", volumeRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 
 			requestStr := fmt.Sprintf("%v", volumeRequest)
@@ -104,7 +104,7 @@ func (s *Service) CreateVolume(ctx context.Context, spec *infrastructurev1beta1.
 	err, httpRes := tag.AddTag(ctx, volumeTagRequest, resourceIds, oscApiClient, oscAuthClient)
 	if err != nil {
 		if httpRes != nil {
-			return nil, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+			return nil, utils.ExtractOAPIError(err, httpRes)
 		} else {
 			return nil, err
 		}
@@ -131,7 +131,7 @@ func (s *Service) GetVolume(ctx context.Context, volumeId string) (*osc.Volume, 
 		utils.LogAPICall(ctx, "ReadVolumes", readVolumesRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", readVolumesRequest)
 			if reconciler.KeepRetryWithError(
@@ -178,7 +178,7 @@ func (s *Service) LinkVolume(ctx context.Context, volumeId string, vmId string, 
 		utils.LogAPICall(ctx, "LinkVolume", linkVolumeRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", linkVolumeRequest)
 			if reconciler.KeepRetryWithError(
@@ -214,7 +214,7 @@ func (s *Service) UnlinkVolume(ctx context.Context, volumeId string) error {
 		utils.LogAPICall(ctx, "UnlinkVolume", unlinkVolumeRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", unlinkVolumeRequest)
 			if reconciler.KeepRetryWithError(
@@ -247,7 +247,7 @@ func (s *Service) DeleteVolume(ctx context.Context, volumeId string) error {
 		utils.LogAPICall(ctx, "DeleteVolume", deleteVolumeRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", deleteVolumeRequest)
 			if reconciler.KeepRetryWithError(
@@ -285,7 +285,7 @@ func (s *Service) ValidateVolumeIds(ctx context.Context, volumeIds []string) ([]
 		utils.LogAPICall(ctx, "ReadVolumes", readVolumeRequest, httpRes, err)
 		if err != nil {
 			if httpRes != nil {
-				return false, fmt.Errorf("error %w httpRes %s", err, httpRes.Status)
+				return false, utils.ExtractOAPIError(err, httpRes)
 			}
 			requestStr := fmt.Sprintf("%v", readVolumeRequest)
 			if reconciler.KeepRetryWithError(

--- a/cloud/utils/errors.go
+++ b/cloud/utils/errors.go
@@ -1,0 +1,40 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/outscale/osc-sdk-go/v2"
+)
+
+type OAPIError struct {
+	errors []osc.Errors
+}
+
+func (err OAPIError) Error() string {
+	if len(err.errors) == 0 {
+		return "unknown error"
+	}
+	oe := err.errors[0]
+	str := oe.GetCode() + "/" + oe.GetType()
+	details := oe.GetDetails()
+	if details != "" {
+		str += " (" + details + ")"
+	}
+	return str
+}
+
+func ExtractOAPIError(err error, httpRes *http.Response) error {
+	var genericError osc.GenericOpenAPIError
+	if errors.As(err, &genericError) {
+		errorsResponse, ok := genericError.Model().(osc.ErrorResponse)
+		if ok && len(*errorsResponse.Errors) > 0 {
+			return OAPIError{errors: *errorsResponse.Errors}
+		}
+	}
+	if httpRes != nil {
+		return fmt.Errorf("http error %w", err)
+	}
+	return err
+}


### PR DESCRIPTION
This PR changes OAPI error messages from:

`cannot create vm: error 400 Bad Request httpRes 400 Bad Request`

to:

`cannot create vm: InvalidResource/5023 (The ImageId 'ami-e1a786f1' doesn't exist.)`


