### PR TITLE
🐛 fix: properly handle partially created resources (wip)

### DIFF
--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -133,6 +133,11 @@ func (s *ClusterScope) GetNatService() *infrastructurev1beta1.OscNatService {
 
 // GetNatServices return the natServices of the cluster
 func (s *ClusterScope) GetNatServices() []*infrastructurev1beta1.OscNatService {
+	if len(s.OscCluster.Spec.Network.NatServices) == 0 {
+		nat := s.GetNatService()
+		nat.SetDefaultValue()
+		return []*infrastructurev1beta1.OscNatService{nat}
+	}
 	return s.OscCluster.Spec.Network.NatServices
 }
 

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -184,11 +184,13 @@ func mockReadTagByNameNoneFound(name string) mockFunc {
 	}
 }
 
-func mockReadTagByNameFound(name string) mockFunc {
+func mockReadTagByNameFound(name, resourceId string) mockFunc {
 	return func(s *MockCloudServices) {
 		s.TagMock.EXPECT().
 			ReadTag(gomock.Any(), gomock.Eq("Name"), gomock.Eq(name)).
-			Return(&osc.Tag{}, nil)
+			Return(&osc.Tag{
+				ResourceId: &resourceId,
+			}, nil)
 	}
 }
 

--- a/controllers/osccluster_controller_test.go
+++ b/controllers/osccluster_controller_test.go
@@ -74,46 +74,139 @@ func runClusterTest(t *testing.T, tc testcase) {
 	}
 }
 
+func TestReconcileOSCCluster_Create(t *testing.T) {
+	tcs := []testcase{
+		{
+			name:        "creating a cluster",
+			clusterSpec: "base",
+			mockFuncs: []mockFunc{
+				mockNetFound("vpc-24ba90ce"), mockGetSubnetIdsFromNetIds("vpc-24ba90ce", []string{
+					"subnet-c1a282b0", "subnet-1555ea91", "subnet-174f5ec4",
+				}),
+				mockReadTagByNameFound("test-cluster-api-subnet-kw-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockReadTagByNameFound("test-cluster-api-subnet-kcp-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockReadTagByNameFound("test-cluster-api-subnet-public-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+
+				mockReadTagByNameFound("test-cluster-api-internetservice-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockInternetServiceFound("igw-c3c49899"),
+
+				mockValidatePublicIpIdsOk([]string{"eipalloc-da72a57c"}),
+				mockReadTagByNameFound("test-cluster-api-publicip-nat-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+
+				mockSecurityGroupsForNetFound("vpc-24ba90ce", []string{"sg-750ae810", "sg-a093d014", "sg-7eb16ccb", "sg-0cd1f87e"}),
+				mockReadTagByNameFound("test-cluster-api-securitygroup-kw-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockReadTagByNameFound("test-cluster-api-securitygroup-kcp-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockReadTagByNameFound("test-cluster-api-securitygroup-lb-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockReadTagByNameFound("test-cluster-api-securitygroup-node-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+
+				mockRouteTablesForNetFound("vpc-24ba90ce", []string{"rtb-194c971e", "rtb-0a4640a6", "rtb-eeacfe8a"}),
+				mockReadTagByNameFound("test-cluster-api-routetable-kcp-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockReadTagByNameFound("test-cluster-api-routetable-kw-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockReadTagByNameFound("test-cluster-api-routetable-public-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+
+				mockReadTagByNameFound("test-cluster-api-natservice-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockNatServiceFound("nat-223a4dd4"),
+
+				mockRouteTablesForNetFound("vpc-24ba90ce", []string{"rtb-194c971e", "rtb-0a4640a6", "rtb-eeacfe8a"}),
+				mockReadTagByNameFound("test-cluster-api-routetable-kcp-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockReadTagByNameFound("test-cluster-api-routetable-kw-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockReadTagByNameFound("test-cluster-api-routetable-public-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+
+				mockLoadBalancerFound("test-cluster-api-k8s", true),
+				mockLoadBalancerTagFound("test-cluster-api-k8s", "test-cluster-api-k8s-9e1db9c4-bf0a-4583-8999-203ec002c520"),
+			},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			runClusterTest(t, tc)
+		})
+	}
+}
+
 func TestReconcileOSCCluster_Update(t *testing.T) {
 	tcs := []testcase{
+		{
+			// TODO: assert that status is correctly setup
+			name:           "when no resource id are stored, resources are found by tag",
+			clusterSpec:    "ready",
+			clusterPatches: []patchOSCClusterFunc{patchClusterNoResourceId()},
+			mockFuncs: []mockFunc{
+				mockReadTagByNameFound("test-cluster-api-net-9e1db9c4-bf0a-4583-8999-203ec002c520", "vpc-24ba90ce"),
+				mockGetSubnetIdsFromNetIds("vpc-24ba90ce", []string{
+					"subnet-c1a282b0", "subnet-1555ea91", "subnet-174f5ec4",
+				}),
+				mockReadTagByNameFound("test-cluster-api-subnet-kw-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockReadTagByNameFound("test-cluster-api-subnet-kcp-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockReadTagByNameFound("test-cluster-api-subnet-public-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+
+				mockReadTagByNameFound("test-cluster-api-internetservice-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockInternetServiceFound("igw-c3c49899"),
+
+				mockValidatePublicIpIdsOk([]string{"eipalloc-da72a57c"}),
+				mockReadTagByNameFound("test-cluster-api-publicip-nat-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+
+				mockSecurityGroupsForNetFound("vpc-24ba90ce", []string{"sg-750ae810", "sg-a093d014", "sg-7eb16ccb", "sg-0cd1f87e"}),
+				mockReadTagByNameFound("test-cluster-api-securitygroup-kw-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockReadTagByNameFound("test-cluster-api-securitygroup-kcp-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockReadTagByNameFound("test-cluster-api-securitygroup-lb-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockReadTagByNameFound("test-cluster-api-securitygroup-node-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+
+				mockRouteTablesForNetFound("vpc-24ba90ce", []string{"rtb-194c971e", "rtb-0a4640a6", "rtb-eeacfe8a"}),
+				mockReadTagByNameFound("test-cluster-api-routetable-kcp-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockReadTagByNameFound("test-cluster-api-routetable-kw-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockReadTagByNameFound("test-cluster-api-routetable-public-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+
+				mockReadTagByNameFound("test-cluster-api-natservice-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockNatServiceFound("nat-223a4dd4"),
+
+				mockRouteTablesForNetFound("vpc-24ba90ce", []string{"rtb-194c971e", "rtb-0a4640a6", "rtb-eeacfe8a"}),
+				mockReadTagByNameFound("test-cluster-api-routetable-kcp-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockReadTagByNameFound("test-cluster-api-routetable-kw-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockReadTagByNameFound("test-cluster-api-routetable-public-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+
+				mockLoadBalancerFound("test-cluster-api-k8s", true),
+				mockLoadBalancerTagFound("test-cluster-api-k8s", "test-cluster-api-k8s-9e1db9c4-bf0a-4583-8999-203ec002c520"),
+			},
+		},
 		{
 			// TODO: assert that status is correctly setup
 			name:           "cluster has been moved by clusterctl move, status is updated",
 			clusterSpec:    "ready",
 			clusterPatches: []patchOSCClusterFunc{patchMoveCluster()},
 			mockFuncs: []mockFunc{
-				mockReadTagByNameFound("test-cluster-api-net-9e1db9c4-bf0a-4583-8999-203ec002c520"),
-				mockNetFound("vpc-24ba90ce"), mockGetSubnetIdsFromNetIds("vpc-24ba90ce", []string{
+				mockNetFound("vpc-24ba90ce"),
+				mockGetSubnetIdsFromNetIds("vpc-24ba90ce", []string{
 					"subnet-c1a282b0", "subnet-1555ea91", "subnet-174f5ec4",
 				}),
-				mockReadTagByNameFound("test-cluster-api-subnet-kw-9e1db9c4-bf0a-4583-8999-203ec002c520"),
-				mockReadTagByNameFound("test-cluster-api-subnet-kcp-9e1db9c4-bf0a-4583-8999-203ec002c520"),
-				mockReadTagByNameFound("test-cluster-api-subnet-public-9e1db9c4-bf0a-4583-8999-203ec002c520"),
+				mockReadTagByNameFound("test-cluster-api-subnet-kw-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockReadTagByNameFound("test-cluster-api-subnet-kcp-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockReadTagByNameFound("test-cluster-api-subnet-public-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
 
-				mockReadTagByNameFound("test-cluster-api-internetservice-9e1db9c4-bf0a-4583-8999-203ec002c520"),
+				mockReadTagByNameFound("test-cluster-api-internetservice-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
 				mockInternetServiceFound("igw-c3c49899"),
 
 				mockValidatePublicIpIdsOk([]string{"eipalloc-da72a57c"}),
-				mockReadTagByNameFound("test-cluster-api-publicip-nat-9e1db9c4-bf0a-4583-8999-203ec002c520"),
+				mockReadTagByNameFound("test-cluster-api-publicip-nat-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
 
 				mockSecurityGroupsForNetFound("vpc-24ba90ce", []string{"sg-750ae810", "sg-a093d014", "sg-7eb16ccb", "sg-0cd1f87e"}),
-				mockReadTagByNameFound("test-cluster-api-securitygroup-kw-9e1db9c4-bf0a-4583-8999-203ec002c520"),
-				mockReadTagByNameFound("test-cluster-api-securitygroup-kcp-9e1db9c4-bf0a-4583-8999-203ec002c520"),
-				mockReadTagByNameFound("test-cluster-api-securitygroup-lb-9e1db9c4-bf0a-4583-8999-203ec002c520"),
-				mockReadTagByNameFound("test-cluster-api-securitygroup-node-9e1db9c4-bf0a-4583-8999-203ec002c520"),
+				mockReadTagByNameFound("test-cluster-api-securitygroup-kw-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockReadTagByNameFound("test-cluster-api-securitygroup-kcp-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockReadTagByNameFound("test-cluster-api-securitygroup-lb-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockReadTagByNameFound("test-cluster-api-securitygroup-node-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
 
 				mockRouteTablesForNetFound("vpc-24ba90ce", []string{"rtb-194c971e", "rtb-0a4640a6", "rtb-eeacfe8a"}),
-				mockReadTagByNameFound("test-cluster-api-routetable-kcp-9e1db9c4-bf0a-4583-8999-203ec002c520"),
-				mockReadTagByNameFound("test-cluster-api-routetable-kw-9e1db9c4-bf0a-4583-8999-203ec002c520"),
-				mockReadTagByNameFound("test-cluster-api-routetable-public-9e1db9c4-bf0a-4583-8999-203ec002c520"),
+				mockReadTagByNameFound("test-cluster-api-routetable-kcp-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockReadTagByNameFound("test-cluster-api-routetable-kw-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockReadTagByNameFound("test-cluster-api-routetable-public-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
 
-				mockReadTagByNameFound("test-cluster-api-natservice-9e1db9c4-bf0a-4583-8999-203ec002c520"),
+				mockReadTagByNameFound("test-cluster-api-natservice-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
 				mockNatServiceFound("nat-223a4dd4"),
 
 				mockRouteTablesForNetFound("vpc-24ba90ce", []string{"rtb-194c971e", "rtb-0a4640a6", "rtb-eeacfe8a"}),
-				mockReadTagByNameFound("test-cluster-api-routetable-kcp-9e1db9c4-bf0a-4583-8999-203ec002c520"),
-				mockReadTagByNameFound("test-cluster-api-routetable-kw-9e1db9c4-bf0a-4583-8999-203ec002c520"),
-				mockReadTagByNameFound("test-cluster-api-routetable-public-9e1db9c4-bf0a-4583-8999-203ec002c520"),
+				mockReadTagByNameFound("test-cluster-api-routetable-kcp-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockReadTagByNameFound("test-cluster-api-routetable-kw-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
+				mockReadTagByNameFound("test-cluster-api-routetable-public-9e1db9c4-bf0a-4583-8999-203ec002c520", "foo"),
 
 				mockLoadBalancerFound("test-cluster-api-k8s", true),
 				mockLoadBalancerTagFound("test-cluster-api-k8s", "test-cluster-api-k8s-9e1db9c4-bf0a-4583-8999-203ec002c520"),

--- a/controllers/osccluster_helpers_test.go
+++ b/controllers/osccluster_helpers_test.go
@@ -15,6 +15,27 @@ func patchMoveCluster() patchOSCClusterFunc {
 	}
 }
 
+func patchClusterNoResourceId() patchOSCClusterFunc {
+	return func(m *v1beta1.OscCluster) {
+		m.Spec.Network.Bastion.ResourceId = ""
+		m.Spec.Network.InternetService.ResourceId = ""
+		m.Spec.Network.NatService.ResourceId = ""
+		m.Spec.Network.Net.ResourceId = ""
+		for i := range m.Spec.Network.Subnets {
+			m.Spec.Network.Subnets[i].ResourceId = ""
+		}
+		for i := range m.Spec.Network.PublicIps {
+			m.Spec.Network.PublicIps[i].ResourceId = ""
+		}
+		for i := range m.Spec.Network.RouteTables {
+			m.Spec.Network.RouteTables[i].ResourceId = ""
+		}
+		for i := range m.Spec.Network.SecurityGroups {
+			m.Spec.Network.SecurityGroups[i].ResourceId = ""
+		}
+	}
+}
+
 func patchDeleteCluster() patchOSCClusterFunc {
 	return func(m *v1beta1.OscCluster) {
 		m.DeletionTimestamp = ptr.To(metav1.Now())

--- a/controllers/osccluster_loadbalancer_controller.go
+++ b/controllers/osccluster_loadbalancer_controller.go
@@ -185,23 +185,23 @@ func reconcileLoadBalancer(ctx context.Context, clusterScope *scope.ClusterScope
 	}
 
 	if loadbalancer == nil {
-		log.V(2).Info("Creating loadBalancer", "loadBalancerName", loadBalancerName)
+		log.V(3).Info("Creating loadBalancer", "loadBalancerName", loadBalancerName)
 		_, err := loadBalancerSvc.CreateLoadBalancer(ctx, loadBalancerSpec, subnetId, securityGroupId)
 		if err != nil {
 			return reconcile.Result{}, fmt.Errorf("cannot create loadBalancer: %w", err)
 		}
-		log.V(2).Info("Deleting default outbound sg rule for loadBalancer", "loadBalancerName", loadBalancerName)
+		log.V(2).Info("Created loadBalancer", "loadBalancerName", loadBalancerName)
+		log.V(4).Info("Deleting default outbound sg rule for loadBalancer", "loadBalancerName", loadBalancerName)
 		err = securityGroupSvc.DeleteSecurityGroupRule(ctx, securityGroupId, "Outbound", "-1", "0.0.0.0/0", "", 0, 0)
 		if err != nil {
 			return reconcile.Result{}, fmt.Errorf("cannot delete default sg rules for loadBalancer: %w", err)
 		}
-		log.V(2).Info("Configuring loadBalancer healthcheck", "loadBalancerName", loadBalancerName)
+		log.V(3).Info("Configuring loadBalancer healthcheck", "loadBalancerName", loadBalancerName)
 		loadbalancer, err = loadBalancerSvc.ConfigureHealthCheck(ctx, loadBalancerSpec)
-		log.V(4).Info("Get loadbalancer", "loadbalancer", loadbalancer)
 		if err != nil {
 			return reconcile.Result{}, fmt.Errorf("cannot configure healthcheck: %w", err)
 		}
-		log.V(2).Info("Creating loadBalancer tag name", "loadBalancerName", loadBalancerName)
+		log.V(3).Info("Creating loadBalancer tag name", "loadBalancerName", loadBalancerName)
 		err = loadBalancerSvc.CreateLoadBalancerTag(ctx, loadBalancerSpec, nameTag)
 		if err != nil {
 			return reconcile.Result{}, fmt.Errorf("cannot tag loadBalancer: %w", err)

--- a/controllers/osccluster_routetable_controller.go
+++ b/controllers/osccluster_routetable_controller.go
@@ -163,17 +163,17 @@ func reconcileRoute(ctx context.Context, clusterScope *scope.ClusterScope, route
 	}
 	destinationIpRange := routeSpec.Destination
 	associateRouteTableId := routeTablesRef.ResourceMap[routeTableName]
-	log.V(4).Info("Checking route", "routename", routeName)
 	routeTableFromRoute, err := routeTableSvc.GetRouteTableFromRoute(ctx, associateRouteTableId, resourceId, resourceType)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("cannot get route table: %w", err)
 	}
 	if routeTableFromRoute == nil {
-		log.V(2).Info("Creating route", "routeName", routeName)
+		log.V(3).Info("Creating route", "routeName", routeName)
 		routeTableFromRoute, err = routeTableSvc.CreateRoute(ctx, destinationIpRange, routeTablesRef.ResourceMap[routeTableName], resourceId, resourceType)
 		if err != nil {
 			return reconcile.Result{}, fmt.Errorf("cannot create route: %w", err)
 		}
+		log.V(2).Info("Created route", "routeId", routeTableFromRoute.GetRouteTableId())
 	}
 
 	routeRef.ResourceMap[routeName] = routeTableFromRoute.GetRouteTableId()


### PR DESCRIPTION
Many edge cases are not properly handled.

1/ OscK8sClusterID tag failure

If the OscK8sClusterID tag creation failed, the tag is present, but the ResourceId is not recorded, leading to inifinite loops.

2/ InternetService net linking failures

If LinkInternetService fails, the next reconciliation will not retry, leading to a non working internet service.

This PR also:
* rewrites SG rules update reconciliation, removing the need for the extraSecurityGroup flag,
* removes an unnecessary tag call when the resource already exist.

