### PR TITLE
🔥 cleanup/vm: remove GetVmState

### DIFF
--- a/cloud/services/compute/mock_compute/vm_mock.go
+++ b/cloud/services/compute/mock_compute/vm_mock.go
@@ -130,18 +130,3 @@ func (mr *MockOscVmInterfaceMockRecorder) GetVmListFromTag(ctx, tagKey, tagName 
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVmListFromTag", reflect.TypeOf((*MockOscVmInterface)(nil).GetVmListFromTag), ctx, tagKey, tagName)
 }
-
-// GetVmState mocks base method.
-func (m *MockOscVmInterface) GetVmState(ctx context.Context, vmId string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetVmState", ctx, vmId)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetVmState indicates an expected call of GetVmState.
-func (mr *MockOscVmInterfaceMockRecorder) GetVmState(ctx, vmId any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVmState", reflect.TypeOf((*MockOscVmInterface)(nil).GetVmState), ctx, vmId)
-}

--- a/cloud/services/compute/vm.go
+++ b/cloud/services/compute/vm.go
@@ -43,7 +43,6 @@ type OscVmInterface interface {
 	DeleteVm(ctx context.Context, vmId string) error
 	GetVm(ctx context.Context, vmId string) (*osc.Vm, error)
 	GetVmListFromTag(ctx context.Context, tagKey string, tagName string) ([]osc.Vm, error)
-	GetVmState(ctx context.Context, vmId string) (string, error)
 	AddCcmTag(ctx context.Context, clusterName string, hostname string, vmId string) error
 }
 
@@ -387,19 +386,6 @@ func (s *Service) GetVmListFromTag(ctx context.Context, tagKey string, tagValue 
 		vmList := *vms
 		return vmList, nil
 	}
-}
-
-// GetVmState return vm state
-func (s *Service) GetVmState(ctx context.Context, vmId string) (string, error) {
-	vm, err := s.GetVm(ctx, vmId)
-	if err != nil {
-		return "", err
-	}
-	vmState, ok := vm.GetStateOk()
-	if !ok {
-		return "", errors.New("cannot get vm state")
-	}
-	return *vmState, nil
 }
 
 // AddCcmTag add ccm tag

--- a/controllers/osccluster_bastion_controller.go
+++ b/controllers/osccluster_bastion_controller.go
@@ -293,15 +293,11 @@ func reconcileBastion(ctx context.Context, clusterScope *scope.ClusterScope, vmS
 	if bastionState != nil {
 		if *bastionState != infrastructurev1beta1.VmStateRunning {
 			vmId := bastionSpec.ResourceId
-			_, err = vmSvc.GetVm(ctx, vmId)
+			vm, err := vmSvc.GetVm(ctx, vmId)
 			if err != nil {
 				return reconcile.Result{}, err
 			}
-			currentVmState, err := vmSvc.GetVmState(ctx, vmId)
-			if err != nil {
-				clusterScope.SetVmState(infrastructurev1beta1.VmState("unknown"))
-				return reconcile.Result{}, fmt.Errorf("cannot get bastion %s state: %w", vmId, err)
-			}
+			currentVmState := vm.GetState()
 			clusterScope.SetVmState(infrastructurev1beta1.VmState(currentVmState))
 			log.V(4).Info("Bastion vm state", "vmState", currentVmState)
 

--- a/controllers/osccluster_bastion_controller_unit_test.go
+++ b/controllers/osccluster_bastion_controller_unit_test.go
@@ -1675,12 +1675,7 @@ func TestReconcileBastion(t *testing.T) {
 						// Mock GetVm
 					mockOscVmInterface.EXPECT().
 						GetVm(gomock.Any(), vmId).
-						Return(&osc.Vm{VmId: &vmId}, nil)
-
-					// Mock GetVmState
-					mockOscVmInterface.EXPECT().
-						GetVmState(gomock.Any(), vmId).
-						Return("running", nil)
+						Return(&osc.Vm{VmId: &vmId, State: ptr.To("running")}, nil)
 
 					if btc.expLinkPublicIpFound {
 						mockOscPublicIpInterface.EXPECT().

--- a/controllers/oscmachine_helpers_test.go
+++ b/controllers/oscmachine_helpers_test.go
@@ -120,15 +120,6 @@ func mockGetVm(vmId, state string, deviceAndVolume ...string) mockFunc {
 	}
 }
 
-func mockGetVmState(vmId, state string) mockFunc {
-	return func(s *MockCloudServices) {
-		s.VMMock.
-			EXPECT().
-			GetVmState(gomock.Any(), gomock.Eq(vmId)).
-			Return(state, nil)
-	}
-}
-
 func mockLinkLoadBalancer(vmId, lb string) mockFunc {
 	return func(s *MockCloudServices) {
 		s.LoadBalancerMock.EXPECT().


### PR DESCRIPTION
This removes an OAPI call in bastion reconciliation.