### PR TITLE
♻️ refacto/backoff: remove backoff on main calls, secure backoff on secondary calls

### DIFF
--- a/cloud/services/compute/image.go
+++ b/cloud/services/compute/image.go
@@ -18,13 +18,9 @@ package compute
 
 import (
 	"context"
-	"fmt"
-	"net/http"
 
 	"github.com/outscale/cluster-api-provider-outscale/cloud/utils"
-	"github.com/outscale/cluster-api-provider-outscale/util/reconciler"
 	osc "github.com/outscale/osc-sdk-go/v2"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 //go:generate ../../../bin/mockgen -destination mock_compute/image_mock.go -package mock_compute -source ./image.go
@@ -41,31 +37,10 @@ func (s *Service) GetImage(ctx context.Context, imageId string) (*osc.Image, err
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 
-	var readImagesResponse osc.ReadImagesResponse
-	readImageCallBack := func() (bool, error) {
-		var httpRes *http.Response
-		var err error
-		readImagesResponse, httpRes, err = oscApiClient.ImageApi.ReadImages(oscAuthClient).ReadImagesRequest(readImageRequest).Execute()
-		utils.LogAPICall(ctx, "ReadImages", readImageRequest, httpRes, err)
-		if err != nil {
-			if httpRes != nil {
-				return false, utils.ExtractOAPIError(err, httpRes)
-			}
-			requestStr := fmt.Sprintf("%v", readImageRequest)
-			if reconciler.KeepRetryWithError(
-				requestStr,
-				httpRes.StatusCode,
-				reconciler.ThrottlingErrors) {
-				return false, nil
-			}
-			return false, err
-		}
-		return true, err
-	}
-	backoff := reconciler.EnvBackoff()
-	waitErr := wait.ExponentialBackoff(backoff, readImageCallBack)
-	if waitErr != nil {
-		return nil, waitErr
+	readImagesResponse, httpRes, err := oscApiClient.ImageApi.ReadImages(oscAuthClient).ReadImagesRequest(readImageRequest).Execute()
+	utils.LogAPICall(ctx, "ReadImages", readImageRequest, httpRes, err)
+	if err != nil {
+		return nil, utils.ExtractOAPIError(err, httpRes)
 	}
 	if len(readImagesResponse.GetImages()) == 0 {
 		return nil, nil
@@ -87,31 +62,10 @@ func (s *Service) GetImageByName(ctx context.Context, imageName, accountId strin
 	}
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
-	var readImagesResponse osc.ReadImagesResponse
-	readImageCallBack := func() (bool, error) {
-		var httpRes *http.Response
-		var err error
-		readImagesResponse, httpRes, err = oscApiClient.ImageApi.ReadImages(oscAuthClient).ReadImagesRequest(readImageRequest).Execute()
-		utils.LogAPICall(ctx, "ReadImages", readImageRequest, httpRes, err)
-		if err != nil {
-			if httpRes != nil {
-				return false, utils.ExtractOAPIError(err, httpRes)
-			}
-			requestStr := fmt.Sprintf("%v", readImageRequest)
-			if reconciler.KeepRetryWithError(
-				requestStr,
-				httpRes.StatusCode,
-				reconciler.ThrottlingErrors) {
-				return false, nil
-			}
-			return false, err
-		}
-		return true, err
-	}
-	backoff := reconciler.EnvBackoff()
-	waitErr := wait.ExponentialBackoff(backoff, readImageCallBack)
-	if waitErr != nil {
-		return nil, waitErr
+	readImagesResponse, httpRes, err := oscApiClient.ImageApi.ReadImages(oscAuthClient).ReadImagesRequest(readImageRequest).Execute()
+	utils.LogAPICall(ctx, "ReadImages", readImageRequest, httpRes, err)
+	if err != nil {
+		return nil, utils.ExtractOAPIError(err, httpRes)
 	}
 	if len(readImagesResponse.GetImages()) == 0 {
 		return nil, nil

--- a/cloud/services/service/load_balancer.go
+++ b/cloud/services/service/load_balancer.go
@@ -19,16 +19,15 @@ package service
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/benbjohnson/clock"
 	infrastructurev1beta1 "github.com/outscale/cluster-api-provider-outscale/api/v1beta1"
 	"github.com/outscale/cluster-api-provider-outscale/cloud/utils"
-	"github.com/outscale/cluster-api-provider-outscale/util/reconciler"
 	osc "github.com/outscale/osc-sdk-go/v2"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
 )
 
 //go:generate ../../../bin/mockgen -destination mock_service/loadbalancer_mock.go -package mock_service -source ./load_balancer.go
@@ -57,6 +56,7 @@ func ValidateProtocol(protocol string) (string, error) {
 }
 
 // ConfigureHealthCheck update loadBalancer to configure healthCheck
+// Keep backoff: secondary call to CreateLoadBalancer
 func (s *Service) ConfigureHealthCheck(ctx context.Context, spec *infrastructurev1beta1.OscLoadBalancer) (*osc.LoadBalancer, error) {
 	checkInterval := spec.HealthCheck.CheckInterval
 	healthyThreshold := spec.HealthCheck.HealthyThreshold
@@ -86,21 +86,14 @@ func (s *Service) ConfigureHealthCheck(ctx context.Context, spec *infrastructure
 		updateLoadBalancerResponse, httpRes, err = oscApiClient.LoadBalancerApi.UpdateLoadBalancer(oscAuthClient).UpdateLoadBalancerRequest(updateLoadBalancerRequest).Execute()
 		utils.LogAPICall(ctx, "UpdateLoadBalancer", updateLoadBalancerRequest, httpRes, err)
 		if err != nil {
-			if httpRes != nil {
-				return false, utils.ExtractOAPIError(err, httpRes)
-			}
-			requestStr := fmt.Sprintf("%v", updateLoadBalancerRequest)
-			if reconciler.KeepRetryWithError(
-				requestStr,
-				httpRes.StatusCode,
-				reconciler.ThrottlingErrors) {
+			if utils.RetryIf(httpRes) || httpRes == nil {
 				return false, nil
 			}
-			return false, err
+			return false, utils.ExtractOAPIError(err, httpRes)
 		}
 		return true, err
 	}
-	backoff := reconciler.EnvBackoff()
+	backoff := utils.EnvBackoff()
 	waitErr := wait.ExponentialBackoff(backoff, updateLoadBalancerCallBack)
 	if waitErr != nil {
 		return nil, waitErr
@@ -126,21 +119,15 @@ func (s *Service) LinkLoadBalancerBackendMachines(ctx context.Context, vmIds []s
 		_, httpRes, err = oscApiClient.LoadBalancerApi.LinkLoadBalancerBackendMachines(oscAuthClient).LinkLoadBalancerBackendMachinesRequest(linkLoadBalancerBackendMachinesRequest).Execute()
 		utils.LogAPICall(ctx, "LinkLoadBalancerBackendMachines", linkLoadBalancerBackendMachinesRequest, httpRes, err)
 		if err != nil {
-			if httpRes != nil {
-				return false, utils.ExtractOAPIError(err, httpRes)
-			}
-			requestStr := fmt.Sprintf("%v", linkLoadBalancerBackendMachinesRequest)
-			if reconciler.KeepRetryWithError(
-				requestStr,
-				httpRes.StatusCode,
-				reconciler.ThrottlingErrors) {
+			if utils.RetryIf(httpRes) {
+				klog.FromContext(ctx).V(4).Error(err, "retrying on error")
 				return false, nil
 			}
-			return false, err
+			return false, utils.ExtractOAPIError(err, httpRes)
 		}
 		return true, err
 	}
-	backoff := reconciler.EnvBackoff()
+	backoff := utils.EnvBackoff()
 	waitErr := wait.ExponentialBackoff(backoff, linkLoadBalancerBackendMachinesCallBack)
 	if waitErr != nil {
 		return waitErr
@@ -157,32 +144,9 @@ func (s *Service) UnlinkLoadBalancerBackendMachines(ctx context.Context, vmIds [
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 
-	unlinkLoadBalancerBackendMachinesCallBack := func() (bool, error) {
-		var httpRes *http.Response
-		var err error
-		_, httpRes, err = oscApiClient.LoadBalancerApi.UnlinkLoadBalancerBackendMachines(oscAuthClient).UnlinkLoadBalancerBackendMachinesRequest(unlinkLoadBalancerBackendMachinesRequest).Execute()
-		utils.LogAPICall(ctx, "UnlinkLoadBalancerBackendMachines", unlinkLoadBalancerBackendMachinesRequest, httpRes, err)
-		if err != nil {
-			if httpRes != nil {
-				return false, utils.ExtractOAPIError(err, httpRes)
-			}
-			requestStr := fmt.Sprintf("%v", unlinkLoadBalancerBackendMachinesRequest)
-			if reconciler.KeepRetryWithError(
-				requestStr,
-				httpRes.StatusCode,
-				reconciler.ThrottlingErrors) {
-				return false, nil
-			}
-			return false, err
-		}
-		return true, err
-	}
-	backoff := reconciler.EnvBackoff()
-	waitErr := wait.ExponentialBackoff(backoff, unlinkLoadBalancerBackendMachinesCallBack)
-	if waitErr != nil {
-		return waitErr
-	}
-	return nil
+	_, httpRes, err := oscApiClient.LoadBalancerApi.UnlinkLoadBalancerBackendMachines(oscAuthClient).UnlinkLoadBalancerBackendMachinesRequest(unlinkLoadBalancerBackendMachinesRequest).Execute()
+	utils.LogAPICall(ctx, "UnlinkLoadBalancerBackendMachines", unlinkLoadBalancerBackendMachinesRequest, httpRes, err)
+	return utils.ExtractOAPIError(err, httpRes)
 }
 
 // GetLoadBalancer retrieve loadBalancer object from spec
@@ -194,32 +158,10 @@ func (s *Service) GetLoadBalancer(ctx context.Context, loadBalancerName string) 
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 
-	var readLoadBalancersResponse osc.ReadLoadBalancersResponse
-	readLoadBalancerCallBack := func() (bool, error) {
-		var httpRes *http.Response
-		var err error
-		readLoadBalancersResponse, httpRes, err = oscApiClient.LoadBalancerApi.ReadLoadBalancers(oscAuthClient).ReadLoadBalancersRequest(readLoadBalancerRequest).Execute()
-		utils.LogAPICall(ctx, "ReadLoadBalancers", readLoadBalancerRequest, httpRes, err)
-		if err != nil {
-			if httpRes != nil {
-				requestStr := fmt.Sprintf("%v", readLoadBalancerRequest)
-				if reconciler.KeepRetryWithError(
-					requestStr,
-					httpRes.StatusCode,
-					reconciler.ThrottlingErrors) {
-					return false, nil
-				} else {
-					return false, utils.ExtractOAPIError(err, httpRes)
-				}
-			}
-			return false, err
-		}
-		return true, nil
-	}
-	backoff := reconciler.EnvBackoff()
-	waitErr := wait.ExponentialBackoff(backoff, readLoadBalancerCallBack)
-	if waitErr != nil {
-		return nil, waitErr
+	readLoadBalancersResponse, httpRes, err := oscApiClient.LoadBalancerApi.ReadLoadBalancers(oscAuthClient).ReadLoadBalancersRequest(readLoadBalancerRequest).Execute()
+	utils.LogAPICall(ctx, "ReadLoadBalancers", readLoadBalancerRequest, httpRes, err)
+	if err != nil {
+		return nil, utils.ExtractOAPIError(err, httpRes)
 	}
 	var lb []osc.LoadBalancer
 	loadBalancers, ok := readLoadBalancersResponse.GetLoadBalancersOk()
@@ -241,32 +183,12 @@ func (s *Service) GetLoadBalancerTag(ctx context.Context, spec *infrastructurev1
 	readLoadBalancerTagRequest := osc.ReadLoadBalancerTagsRequest{
 		LoadBalancerNames: []string{spec.LoadBalancerName},
 	}
-	var readLoadBalancerTagsResponse osc.ReadLoadBalancerTagsResponse
-	readLoadBalancerTagCallBack := func() (bool, error) {
-		var httpRes *http.Response
-		var err error
-		readLoadBalancerTagsResponse, httpRes, err = oscApiClient.LoadBalancerApi.ReadLoadBalancerTags(oscAuthClient).ReadLoadBalancerTagsRequest(readLoadBalancerTagRequest).Execute()
-		utils.LogAPICall(ctx, "ReadLoadBalancerTags", readLoadBalancerTagRequest, httpRes, err)
-		if err != nil {
-			if httpRes != nil {
-				return false, utils.ExtractOAPIError(err, httpRes)
-			}
-			requestStr := fmt.Sprintf("%v", readLoadBalancerTagRequest)
-			if reconciler.KeepRetryWithError(
-				requestStr,
-				httpRes.StatusCode,
-				reconciler.ThrottlingErrors) {
-				return false, nil
-			}
-			return false, fmt.Errorf("failed to read Tag Name: %w", err)
-		}
-		return true, err
+	readLoadBalancerTagsResponse, httpRes, err := oscApiClient.LoadBalancerApi.ReadLoadBalancerTags(oscAuthClient).ReadLoadBalancerTagsRequest(readLoadBalancerTagRequest).Execute()
+	utils.LogAPICall(ctx, "ReadLoadBalancerTags", readLoadBalancerTagRequest, httpRes, err)
+	if err != nil {
+		return nil, utils.ExtractOAPIError(err, httpRes)
 	}
-	backoff := reconciler.EnvBackoff()
-	waitErr := wait.ExponentialBackoff(backoff, readLoadBalancerTagCallBack)
-	if waitErr != nil {
-		return nil, waitErr
-	}
+
 	var tag []osc.LoadBalancerTag
 	tags, ok := readLoadBalancerTagsResponse.GetTagsOk()
 	if !ok {
@@ -281,6 +203,7 @@ func (s *Service) GetLoadBalancerTag(ctx context.Context, spec *infrastructurev1
 }
 
 // CreateLoadBalancerTag create the load balancer tag
+// Keep backoff for now, secondary call to CreateLoadBalancer.
 func (s *Service) CreateLoadBalancerTag(ctx context.Context, spec *infrastructurev1beta1.OscLoadBalancer, loadBalancerTag *osc.ResourceTag) error {
 	createLoadBalancerTagRequest := osc.CreateLoadBalancerTagsRequest{
 		LoadBalancerNames: []string{spec.LoadBalancerName},
@@ -292,21 +215,14 @@ func (s *Service) CreateLoadBalancerTag(ctx context.Context, spec *infrastructur
 		_, httpRes, err := oscApiClient.LoadBalancerApi.CreateLoadBalancerTags(oscAuthClient).CreateLoadBalancerTagsRequest(createLoadBalancerTagRequest).Execute()
 		utils.LogAPICall(ctx, "CreateLoadBalancerTags", createLoadBalancerTagRequest, httpRes, err)
 		if err != nil {
-			if httpRes != nil {
-				fmt.Printf("Error with http result %s", httpRes.Status)
-			}
-			requestStr := fmt.Sprintf("%v", createLoadBalancerTagRequest)
-			if reconciler.KeepRetryWithError(
-				requestStr,
-				httpRes.StatusCode,
-				reconciler.ThrottlingErrors) {
+			if utils.RetryIf(httpRes) {
 				return false, nil
 			}
-			return false, fmt.Errorf("failed to add Tag: %w", err)
+			return false, utils.ExtractOAPIError(err, httpRes)
 		}
 		return true, err
 	}
-	backoff := reconciler.EnvBackoff()
+	backoff := utils.EnvBackoff()
 	waitErr := wait.ExponentialBackoff(backoff, createLoadBalancerTagCallBack)
 	if waitErr != nil {
 		return waitErr
@@ -339,31 +255,10 @@ func (s *Service) CreateLoadBalancer(ctx context.Context, spec *infrastructurev1
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 
-	var loadBalancerResponse osc.CreateLoadBalancerResponse
-	createLoadBalancerCallBack := func() (bool, error) {
-		var httpRes *http.Response
-		var err error
-		loadBalancerResponse, httpRes, err = oscApiClient.LoadBalancerApi.CreateLoadBalancer(oscAuthClient).CreateLoadBalancerRequest(loadBalancerRequest).Execute()
-		utils.LogAPICall(ctx, "CreateLoadBalancer", loadBalancerRequest, httpRes, err)
-		if err != nil {
-			if httpRes != nil {
-				return false, utils.ExtractOAPIError(err, httpRes)
-			}
-			requestStr := fmt.Sprintf("%v", loadBalancerRequest)
-			if reconciler.KeepRetryWithError(
-				requestStr,
-				httpRes.StatusCode,
-				reconciler.ThrottlingErrors) {
-				return false, nil
-			}
-			return false, err
-		}
-		return true, err
-	}
-	backoff := reconciler.EnvBackoff()
-	waitErr := wait.ExponentialBackoff(backoff, createLoadBalancerCallBack)
-	if waitErr != nil {
-		return nil, waitErr
+	loadBalancerResponse, httpRes, err := oscApiClient.LoadBalancerApi.CreateLoadBalancer(oscAuthClient).CreateLoadBalancerRequest(loadBalancerRequest).Execute()
+	utils.LogAPICall(ctx, "CreateLoadBalancer", loadBalancerRequest, httpRes, err)
+	if err != nil {
+		return nil, utils.ExtractOAPIError(err, httpRes)
 	}
 	loadBalancer, ok := loadBalancerResponse.GetLoadBalancerOk()
 	if !ok {
@@ -379,32 +274,9 @@ func (s *Service) DeleteLoadBalancer(ctx context.Context, spec *infrastructurev1
 	}
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
-	deleteLoadBalancerCallBack := func() (bool, error) {
-		var httpRes *http.Response
-		var err error
-		_, httpRes, err = oscApiClient.LoadBalancerApi.DeleteLoadBalancer(oscAuthClient).DeleteLoadBalancerRequest(deleteLoadBalancerRequest).Execute()
-		utils.LogAPICall(ctx, "DeleteLoadBalancer", deleteLoadBalancerRequest, httpRes, err)
-		if err != nil {
-			if httpRes != nil {
-				return false, utils.ExtractOAPIError(err, httpRes)
-			}
-			requestStr := fmt.Sprintf("%v", deleteLoadBalancerRequest)
-			if reconciler.KeepRetryWithError(
-				requestStr,
-				httpRes.StatusCode,
-				reconciler.ThrottlingErrors) {
-				return false, nil
-			}
-			return false, err
-		}
-		return true, err
-	}
-	backoff := reconciler.EnvBackoff()
-	waitErr := wait.ExponentialBackoff(backoff, deleteLoadBalancerCallBack)
-	if waitErr != nil {
-		return waitErr
-	}
-	return nil
+	_, httpRes, err := oscApiClient.LoadBalancerApi.DeleteLoadBalancer(oscAuthClient).DeleteLoadBalancerRequest(deleteLoadBalancerRequest).Execute()
+	utils.LogAPICall(ctx, "DeleteLoadBalancer", deleteLoadBalancerRequest, httpRes, err)
+	return utils.ExtractOAPIError(err, httpRes)
 }
 
 // DeleteLoadBalancerTag delete the loadbalancerTag
@@ -415,32 +287,9 @@ func (s *Service) DeleteLoadBalancerTag(ctx context.Context, spec *infrastructur
 	}
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
-	deleteLoadBalancerTagCallBack := func() (bool, error) {
-		var httpRes *http.Response
-		var err error
-		_, httpRes, err = oscApiClient.LoadBalancerApi.DeleteLoadBalancerTags(oscAuthClient).DeleteLoadBalancerTagsRequest(deleteLoadBalancerTagRequest).Execute()
-		utils.LogAPICall(ctx, "DeleteLoadBalancerTags", deleteLoadBalancerTagRequest, httpRes, err)
-		if err != nil {
-			if httpRes != nil {
-				return false, utils.ExtractOAPIError(err, httpRes)
-			}
-			requestStr := fmt.Sprintf("%v", deleteLoadBalancerTagRequest)
-			if reconciler.KeepRetryWithError(
-				requestStr,
-				httpRes.StatusCode,
-				reconciler.ThrottlingErrors) {
-				return false, nil
-			}
-			return false, err
-		}
-		return true, err
-	}
-	backoff := reconciler.EnvBackoff()
-	waitErr := wait.ExponentialBackoff(backoff, deleteLoadBalancerTagCallBack)
-	if waitErr != nil {
-		return waitErr
-	}
-	return nil
+	_, httpRes, err := oscApiClient.LoadBalancerApi.DeleteLoadBalancerTags(oscAuthClient).DeleteLoadBalancerTagsRequest(deleteLoadBalancerTagRequest).Execute()
+	utils.LogAPICall(ctx, "DeleteLoadBalancerTags", deleteLoadBalancerTagRequest, httpRes, err)
+	return utils.ExtractOAPIError(err, httpRes)
 }
 
 // CheckLoadBalancerDeregisterVm check vm is deregister as vm backend in loadBalancer

--- a/cloud/utils/backoff.go
+++ b/cloud/utils/backoff.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"net/http"
+	"os"
+	"slices"
+	"strconv"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+var throttlingErrors = []int{429, 503}
+
+// getEnv return env variable
+func getEnv(key string, defaultValue string) string {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	return value
+}
+
+// RetryIf tries on TCP errors (httpResp is nil) or on specific HTTP codes.
+func RetryIf(httpResp *http.Response) bool {
+	if httpResp == nil {
+		return true
+	}
+	return slices.Contains(throttlingErrors, httpResp.StatusCode)
+}
+
+// EnvBackoff is the environment for backoff function.
+func EnvBackoff() wait.Backoff {
+	// BACKOFF_DURATION integer in second The initial duration.
+	duration, err := strconv.Atoi(getEnv("BACKOFF_DURATION", "1"))
+	if err != nil {
+		duration = 1
+	}
+
+	// BACKOFF_FACTOR float Duration is multiplied by factor each iteration
+	factor, err := strconv.ParseFloat(getEnv("BACKOFF_FACTOR", "1.5"), 32)
+	if err != nil {
+		factor = 1.5
+	}
+
+	// BACKOFF_STEPS integer : The remaining number of iterations in which
+	// the duration parameter may change
+	steps, err := strconv.Atoi(getEnv("BACKOFF_STEPS", "10"))
+	if err != nil {
+		steps = 10
+	}
+	return wait.Backoff{
+		Duration: time.Duration(duration) * time.Second,
+		Factor:   factor,
+		Steps:    steps,
+	}
+}

--- a/cloud/utils/errors.go
+++ b/cloud/utils/errors.go
@@ -26,6 +26,9 @@ func (err OAPIError) Error() string {
 }
 
 func ExtractOAPIError(err error, httpRes *http.Response) error {
+	if err == nil {
+		return nil
+	}
 	var genericError osc.GenericOpenAPIError
 	if errors.As(err, &genericError) {
 		errorsResponse, ok := genericError.Model().(osc.ErrorResponse)

--- a/util/reconciler/defaults.go
+++ b/util/reconciler/defaults.go
@@ -17,12 +17,7 @@ limitations under the License.
 package reconciler
 
 import (
-	"fmt"
-	"os"
-	"strconv"
 	"time"
-
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
@@ -30,59 +25,10 @@ const (
 	DefaultMappingTimeout = 60 * time.Second
 )
 
-var ThrottlingErrors = []int{429, 503}
-
 func DefaultedLoopTimeout(timeout time.Duration) time.Duration {
 	if timeout <= 0 {
 		return DefaultLoopTimeout
 	}
 
 	return timeout
-}
-
-// getEnv return env variable
-func getEnv(key string, defaultValue string) string {
-	value := os.Getenv(key)
-	if value == "" {
-		return defaultValue
-	}
-	return value
-}
-
-// KeepRetryWithError retry based on httpResCode and httpResType.
-func KeepRetryWithError(requestStr string, httpCode int, throttlingErrors []int) bool {
-	for _, v := range throttlingErrors {
-		if httpCode == v {
-			fmt.Printf("Retry even if got (%v) error type with code error (%v) on request (%s)", httpCode, throttlingErrors, requestStr)
-			return true
-		}
-	}
-	return false
-}
-
-// EnvBackoff is the environment for backoff function.
-func EnvBackoff() wait.Backoff {
-	// BACKOFF_DURATION integer in second The initial duration.
-	duration, err := strconv.Atoi(getEnv("BACKOFF_DURATION", "1"))
-	if err != nil {
-		duration = 1
-	}
-
-	// BACKOFF_FACTOR float Duration is multiplied by factor each iteration
-	factor, err := strconv.ParseFloat(getEnv("BACKOFF_FACTOR", "1.5"), 32)
-	if err != nil {
-		factor = 1.5
-	}
-
-	// BACKOFF_STEPS integer : The remaining number of iterations in which
-	// the duration parameter may change
-	steps, err := strconv.Atoi(getEnv("BACKOFF_STEPS", "10"))
-	if err != nil {
-		steps = 10
-	}
-	return wait.Backoff{
-		Duration: time.Duration(duration) * time.Second,
-		Factor:   factor,
-		Steps:    steps,
-	}
 }


### PR DESCRIPTION
Since failed reconciliation loops are automatically retried, most API calls do not require backoff.

However,  Backoff is still necessary for certain secondary calls (e.g. resource tagging): a failed secondary call may cause a duplicate (next reconciliation loop will not find the created resource when searching by tag, and a new one will be created), or a misconfigured resource (e.g. LB healthcheck).

Fixes #475

