### PR TITLE
✨ feat: record event on resource creation

### DIFF
--- a/api/v1beta1/conditions_consts.go
+++ b/api/v1beta1/conditions_consts.go
@@ -19,28 +19,31 @@ package v1beta1
 import clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 const (
+	NetCreatedReason              string                  = "NetCreated"
 	NetReadyCondition             clusterv1.ConditionType = "NetReady"
-	NetCreationStartedReason      string                  = "NetCreationStarted"
 	NetReconciliationFailedReason string                  = "NetReconciliationFailed"
 )
 
 const (
+	SubnetCreatedReason               string                  = "SubnetCreated"
 	SubnetsReadyCondition             clusterv1.ConditionType = "SubnetsReady"
 	SubnetsReconciliationFailedReason string                  = "SubnetsReconciliationFailed"
 )
 
 const (
+	InternetServicesCreatedReason  string                  = "InternetServiceCreated"
 	InternetServicesReadyCondition clusterv1.ConditionType = "InternetServiceReady"
 	InternetServicesFailedReason   string                  = "InternetServiceFailed"
 )
 
 const (
+	NatServicesCreatedReason              string                  = "NatServicesCreated"
 	NatServicesReadyCondition             clusterv1.ConditionType = "NatServicesReady"
-	NatServicesCreationStartedReason      string                  = "NatServicesCreationStarted"
 	NatServicesReconciliationFailedReason string                  = "NatServicesReconciliationFailed"
 )
 
 const (
+	RouteTableCreatedReason              string                  = "RouteTableCreated"
 	RouteTablesReadyCondition            clusterv1.ConditionType = "RouteTablesReady"
 	RouteTableReconciliationFailedReason string                  = "RouteTableReconciliationFailed"
 )
@@ -51,18 +54,20 @@ const (
 	VmTerminatedReason                    string                  = "VmTerminated"
 	VmStoppedReason                       string                  = "VmStopped"
 	VmNotReadyReason                      string                  = "VmNotReady"
-	VmProvisionStartedReason              string                  = "VmProvisionStarted"
+	VmCreatedReason                       string                  = "VmCreated"
 	VmProvisionFailedReason               string                  = "VmProvisionFailed"
 	WaitingForClusterInfrastructureReason string                  = "WaitingForClusterInfrastructure"
 	WaitingForBootstrapDataReason         string                  = "WaitingForBoostrapData"
 )
 
 const (
+	SecurityGroupCreatedReason              string                  = "SecurityGroupCreated"
 	SecurityGroupReadyCondition             clusterv1.ConditionType = "SecurityGroupsReady"
 	SecurityGroupReconciliationFailedReason string                  = "SecurityGroupReconciliationFailed"
 )
 
 const (
+	LoadBalancerCreatedReason  string                  = "LoadBalancerCreated"
 	LoadBalancerReadyCondition clusterv1.ConditionType = "LoadBalancerReady"
 	LoadBalancerFailedReason   string                  = "LoadBalancerFailed"
 )

--- a/controllers/osccluster_bastion_controller.go
+++ b/controllers/osccluster_bastion_controller.go
@@ -24,6 +24,7 @@ import (
 	infrastructurev1beta1 "github.com/outscale/cluster-api-provider-outscale/api/v1beta1"
 	"github.com/outscale/cluster-api-provider-outscale/cloud/scope"
 	"github.com/outscale/cluster-api-provider-outscale/cloud/services/compute"
+	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -203,6 +204,7 @@ func (r *OscClusterReconciler) reconcileBastion(ctx context.Context, clusterScop
 	log.V(2).Info("Bastion created", "vmId", vm.GetVmId())
 	r.Tracker.setBastionId(clusterScope, vm.GetVmId())
 	clusterScope.SetVmState(infrastructurev1beta1.VmStatePending)
+	r.Recorder.Event(clusterScope.OscCluster, corev1.EventTypeNormal, infrastructurev1beta1.VmCreatedReason, "Bastion created")
 	return reconcile.Result{}, errors.New("VM is not running yet")
 }
 

--- a/controllers/osccluster_controller_test.go
+++ b/controllers/osccluster_controller_test.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	controllerruntime "sigs.k8s.io/controller-runtime"
@@ -45,7 +46,8 @@ func runClusterTest(t *testing.T, tc testcase) {
 	mockCtrl := gomock.NewController(t)
 	cs := newMockCloudServices(mockCtrl)
 	rec := controllers.OscClusterReconciler{
-		Client: client,
+		Client:   client,
+		Recorder: record.NewFakeRecorder(100),
 		Tracker: &controllers.ClusterResourceTracker{
 			Cloud: cs,
 		},

--- a/controllers/osccluster_internetservice_controller.go
+++ b/controllers/osccluster_internetservice_controller.go
@@ -23,6 +23,7 @@ import (
 
 	infrastructurev1beta1 "github.com/outscale/cluster-api-provider-outscale/api/v1beta1"
 	"github.com/outscale/cluster-api-provider-outscale/cloud/scope"
+	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -61,6 +62,7 @@ func (r *OscClusterReconciler) reconcileInternetService(ctx context.Context, clu
 			return reconcile.Result{}, fmt.Errorf("cannot create internetService: %w", err)
 		}
 		log.V(2).Info("Created internet service", "internetServiceId", internetService.GetInternetServiceId())
+		r.Recorder.Event(clusterScope.OscCluster, corev1.EventTypeNormal, infrastructurev1beta1.InternetServicesCreatedReason, "Internet service created")
 	}
 	log.V(2).Info("Linking internet service to net", "internetServiceId", internetService.GetInternetServiceId(), "netId", netId)
 	err = r.Cloud.InternetService(ctx, *clusterScope).LinkInternetService(ctx, internetService.GetInternetServiceId(), netId)

--- a/controllers/osccluster_loadbalancer_controller.go
+++ b/controllers/osccluster_loadbalancer_controller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/outscale/cluster-api-provider-outscale/cloud/scope"
 	tag "github.com/outscale/cluster-api-provider-outscale/cloud/tag"
 	osc "github.com/outscale/osc-sdk-go/v2"
+	corev1 "k8s.io/api/core/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -97,6 +98,7 @@ func (r *OscClusterReconciler) reconcileLoadBalancer(ctx context.Context, cluste
 		if err != nil {
 			return reconcile.Result{}, fmt.Errorf("cannot create loadBalancer: %w", err)
 		}
+		r.Recorder.Event(clusterScope.OscCluster, corev1.EventTypeNormal, infrastructurev1beta1.LoadBalancerCreatedReason, "Loadbalancer created")
 		log.V(2).Info("Configuring loadBalancer healthcheck", "loadBalancerName", loadBalancerName)
 		_, err = svc.ConfigureHealthCheck(ctx, &loadBalancerSpec)
 		log.V(4).Info("Get loadbalancer", "loadbalancer", loadbalancer)

--- a/controllers/osccluster_natservice_controller.go
+++ b/controllers/osccluster_natservice_controller.go
@@ -23,6 +23,7 @@ import (
 
 	infrastructurev1beta1 "github.com/outscale/cluster-api-provider-outscale/api/v1beta1"
 	"github.com/outscale/cluster-api-provider-outscale/cloud/scope"
+	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -76,6 +77,7 @@ func (r *OscClusterReconciler) reconcileNatService(ctx context.Context, clusterS
 		}
 		log.V(2).Info("Created natService", "natServiceId", natService.GetNatServiceId())
 		r.Tracker.setNatServiceId(clusterScope, natServiceSpec, natService.GetNatServiceId())
+		r.Recorder.Eventf(clusterScope.OscCluster, corev1.EventTypeNormal, infrastructurev1beta1.NatServicesCreatedReason, "NAT created %s", natServiceSpec.SubregionName)
 	}
 	clusterScope.SetReconciliationGeneration(infrastructurev1beta1.ReconcilerNatService)
 	return reconcile.Result{}, nil

--- a/controllers/osccluster_net_controller.go
+++ b/controllers/osccluster_net_controller.go
@@ -23,6 +23,7 @@ import (
 
 	infrastructurev1beta1 "github.com/outscale/cluster-api-provider-outscale/api/v1beta1"
 	"github.com/outscale/cluster-api-provider-outscale/cloud/scope"
+	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -55,6 +56,7 @@ func (r *OscClusterReconciler) reconcileNet(ctx context.Context, clusterScope *s
 	log.V(2).Info("Created net", "netId", net.GetNetId())
 	r.Tracker.setNetId(clusterScope, net.GetNetId())
 	clusterScope.SetReconciliationGeneration(infrastructurev1beta1.ReconcilerNet)
+	r.Recorder.Event(clusterScope.OscCluster, corev1.EventTypeNormal, infrastructurev1beta1.NetCreatedReason, "Net created")
 	return reconcile.Result{}, nil
 }
 

--- a/controllers/osccluster_routetable_controller.go
+++ b/controllers/osccluster_routetable_controller.go
@@ -24,6 +24,7 @@ import (
 	infrastructurev1beta1 "github.com/outscale/cluster-api-provider-outscale/api/v1beta1"
 	"github.com/outscale/cluster-api-provider-outscale/cloud/scope"
 	"github.com/outscale/osc-sdk-go/v2"
+	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -124,6 +125,7 @@ func (r *OscClusterReconciler) reconcileRouteTable(ctx context.Context, clusterS
 					return reconcile.Result{}, fmt.Errorf("cannot create routetable: %w", err)
 				}
 				log.V(2).Info("Created routetable", "routetableId", rtbl.GetRouteTableId())
+				r.Recorder.Eventf(clusterScope.OscCluster, corev1.EventTypeNormal, infrastructurev1beta1.RouteTableCreatedReason, "Route table created %v %s", subnetSpec.Roles, subnetSpec.SubregionName)
 				fallthrough
 			case rtbl != nil && rtblForSubnet[subnetId] == nil:
 				log.V(2).Info("Link routetable with subnet", "routeTableId", rtbl.GetRouteTableId(), "subnetId", subnetId)

--- a/controllers/osccluster_securitygroup_controller.go
+++ b/controllers/osccluster_securitygroup_controller.go
@@ -26,6 +26,7 @@ import (
 	infrastructurev1beta1 "github.com/outscale/cluster-api-provider-outscale/api/v1beta1"
 	"github.com/outscale/cluster-api-provider-outscale/cloud/scope"
 	"github.com/outscale/osc-sdk-go/v2"
+	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -137,6 +138,7 @@ func (r *OscClusterReconciler) reconcileSecurityGroup(ctx context.Context, clust
 			}
 			log.V(2).Info("Created securityGroup", "securityGroupId", securityGroup.GetSecurityGroupId())
 			r.Tracker.setSecurityGroupId(clusterScope, securityGroupSpec, securityGroup.GetSecurityGroupId())
+			r.Recorder.Eventf(clusterScope.OscCluster, corev1.EventTypeNormal, infrastructurev1beta1.SecurityGroupCreatedReason, "Security group created %v", securityGroupSpec.Roles)
 		case err != nil:
 			return reconcile.Result{}, fmt.Errorf("get existing: %w", err)
 		}

--- a/controllers/osccluster_subnet_controller.go
+++ b/controllers/osccluster_subnet_controller.go
@@ -23,6 +23,7 @@ import (
 
 	infrastructurev1beta1 "github.com/outscale/cluster-api-provider-outscale/api/v1beta1"
 	"github.com/outscale/cluster-api-provider-outscale/cloud/scope"
+	corev1 "k8s.io/api/core/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -60,6 +61,7 @@ func (r *OscClusterReconciler) reconcileSubnets(ctx context.Context, clusterScop
 		}
 		log.V(2).Info("Created subnet", "subnetId", subnet.GetSubnetId())
 		r.Tracker.setSubnetId(clusterScope, subnetSpec, subnet.GetSubnetId())
+		r.Recorder.Eventf(clusterScope.OscCluster, corev1.EventTypeNormal, infrastructurev1beta1.SubnetCreatedReason, "Subnet created %v %s", subnetSpec.Roles, subnetSpec.SubregionName)
 	}
 
 	// add failureDomains

--- a/controllers/oscmachine_controller_test.go
+++ b/controllers/oscmachine_controller_test.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	controllerruntime "sigs.k8s.io/controller-runtime"
@@ -48,7 +49,8 @@ func runMachineTest(t *testing.T, tc testcase) {
 	mockCtrl := gomock.NewController(t)
 	cs := newMockCloudServices(mockCtrl)
 	rec := controllers.OscMachineReconciler{
-		Client: client,
+		Client:   client,
+		Recorder: record.NewFakeRecorder(100),
 		Tracker: &controllers.MachineResourceTracker{
 			Cloud: cs,
 		},

--- a/controllers/oscmachine_vm_controller.go
+++ b/controllers/oscmachine_vm_controller.go
@@ -212,6 +212,7 @@ func (r *OscMachineReconciler) reconcileVm(ctx context.Context, clusterScope *sc
 		r.Tracker.trackVm(machineScope, vm)
 		machineScope.SetVmState(infrastructurev1beta1.VmState(vm.GetState()))
 		machineScope.SetProviderID(vm.Placement.GetSubregionName(), vmId)
+		r.Recorder.Event(machineScope.OscMachine, corev1.EventTypeNormal, infrastructurev1beta1.VmCreatedReason, "VM created")
 	}
 
 	if vm.GetState() != "running" {


### PR DESCRIPTION
No events are currently generated by reconcilers. This adds an event on every IaaS resource creation.

```bash
kubectl describe osccluster.infrastructure.cluster.x-k8s.io/test-cluster-api
[...]
Events:
  Type    Reason                  Age   From                   Message
  ----    ------                  ----  ----                   -------
  Normal  NetCreated              11s   osccluster-controller  Net created
  Normal  SubnetCreated           10s   osccluster-controller  Subnet created [loadbalancer nat bastion] cloudgouv-eu-west-1a
  Normal  SubnetCreated           9s    osccluster-controller  Subnet created [controlplane] cloudgouv-eu-west-1a
  Normal  SubnetCreated           8s    osccluster-controller  Subnet created [worker] cloudgouv-eu-west-1a
  Normal  InternetServiceCreated  8s    osccluster-controller  Internet service created
  Normal  RouteTableCreated       7s    osccluster-controller  Route table created [loadbalancer nat bastion]
  Normal  NatServicesCreated      6s    osccluster-controller  NAT created cloudgouv-eu-west-1a
  Normal  RouteTableCreated       5s    osccluster-controller  Route table created [controlplane]
  Normal  RouteTableCreated       5s    osccluster-controller  Route table created [worker]
  Normal  SecurityGroupCreated    4s    osccluster-controller  Security group created [loadbalancer]
  Normal  SecurityGroupCreated    2s    osccluster-controller  Security group created [worker]
```