### PR TITLE
🔊 logs: properly decode 409 errors

### DIFF
--- a/cloud/services/compute/image.go
+++ b/cloud/services/compute/image.go
@@ -38,9 +38,9 @@ func (s *Service) GetImage(ctx context.Context, imageId string) (*osc.Image, err
 	oscAuthClient := s.scope.GetAuth()
 
 	readImagesResponse, httpRes, err := oscApiClient.ImageApi.ReadImages(oscAuthClient).ReadImagesRequest(readImageRequest).Execute()
-	utils.LogAPICall(ctx, "ReadImages", readImageRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "ReadImages", readImageRequest, httpRes, err)
 	if err != nil {
-		return nil, utils.ExtractOAPIError(err, httpRes)
+		return nil, err
 	}
 	if len(readImagesResponse.GetImages()) == 0 {
 		return nil, nil
@@ -63,9 +63,9 @@ func (s *Service) GetImageByName(ctx context.Context, imageName, accountId strin
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	readImagesResponse, httpRes, err := oscApiClient.ImageApi.ReadImages(oscAuthClient).ReadImagesRequest(readImageRequest).Execute()
-	utils.LogAPICall(ctx, "ReadImages", readImageRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "ReadImages", readImageRequest, httpRes, err)
 	if err != nil {
-		return nil, utils.ExtractOAPIError(err, httpRes)
+		return nil, err
 	}
 	if len(readImagesResponse.GetImages()) == 0 {
 		return nil, nil

--- a/cloud/services/compute/vm.go
+++ b/cloud/services/compute/vm.go
@@ -116,9 +116,9 @@ func (s *Service) CreateVm(ctx context.Context,
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	vmResponse, httpRes, err := oscApiClient.VmApi.CreateVms(oscAuthClient).CreateVmsRequest(vmOpt).Execute()
-	utils.LogAPICall(ctx, "CreateVms", vmOpt, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "CreateVms", vmOpt, httpRes, err)
 	if err != nil {
-		return nil, utils.ExtractOAPIError(err, httpRes)
+		return nil, err
 	}
 	vms, ok := vmResponse.GetVmsOk()
 	if !ok {
@@ -186,7 +186,7 @@ func (s *Service) CreateVmBastion(ctx context.Context, spec *infrastructurev1bet
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	vmResponse, httpRes, err := oscApiClient.VmApi.CreateVms(oscAuthClient).CreateVmsRequest(vmOpt).Execute()
-	utils.LogAPICall(ctx, "CreateVms", vmOpt, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "CreateVms", vmOpt, httpRes, err)
 	if err != nil {
 		fmt.Printf("Error with http result %s", httpRes.Status)
 		return nil, err
@@ -223,8 +223,8 @@ func (s *Service) DeleteVm(ctx context.Context, vmId string) error {
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	_, httpRes, err := oscApiClient.VmApi.DeleteVms(oscAuthClient).DeleteVmsRequest(deleteVmsRequest).Execute()
-	utils.LogAPICall(ctx, "DeleteVms", deleteVmsRequest, httpRes, err)
-	return utils.ExtractOAPIError(err, httpRes)
+	err = utils.LogAndExtractError(ctx, "DeleteVms", deleteVmsRequest, httpRes, err)
+	return err
 }
 
 // GetVm retrieve vm from vmId
@@ -237,9 +237,9 @@ func (s *Service) GetVm(ctx context.Context, vmId string) (*osc.Vm, error) {
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	readVmsResponse, httpRes, err := oscApiClient.VmApi.ReadVms(oscAuthClient).ReadVmsRequest(readVmsRequest).Execute()
-	utils.LogAPICall(ctx, "ReadVmsRequest", readVmsRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "ReadVmsRequest", readVmsRequest, httpRes, err)
 	if err != nil {
-		return nil, utils.ExtractOAPIError(err, httpRes)
+		return nil, err
 	}
 
 	vms, ok := readVmsResponse.GetVmsOk()
@@ -264,9 +264,9 @@ func (s *Service) GetVmFromClientToken(ctx context.Context, clientToken string) 
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	readVmsResponse, httpRes, err := oscApiClient.VmApi.ReadVms(oscAuthClient).ReadVmsRequest(readVmsRequest).Execute()
-	utils.LogAPICall(ctx, "ReadVms", readVmsRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "ReadVms", readVmsRequest, httpRes, err)
 	if err != nil {
-		return nil, utils.ExtractOAPIError(err, httpRes)
+		return nil, err
 	}
 
 	vms, ok := readVmsResponse.GetVmsOk()

--- a/cloud/services/net/internetservice.go
+++ b/cloud/services/net/internetservice.go
@@ -43,9 +43,9 @@ func (s *Service) CreateInternetService(ctx context.Context, internetServiceName
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	internetServiceResponse, httpRes, err := oscApiClient.InternetServiceApi.CreateInternetService(oscAuthClient).CreateInternetServiceRequest(internetServiceRequest).Execute()
-	utils.LogAPICall(ctx, "CreateInternetService", internetServiceRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "CreateInternetService", internetServiceRequest, httpRes, err)
 	if err != nil {
-		return nil, utils.ExtractOAPIError(err, httpRes)
+		return nil, err
 	}
 	resourceIds := []string{*internetServiceResponse.InternetService.InternetServiceId}
 	internetServiceTag := osc.ResourceTag{
@@ -77,8 +77,8 @@ func (s *Service) DeleteInternetService(ctx context.Context, internetServiceId s
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	_, httpRes, err := oscApiClient.InternetServiceApi.DeleteInternetService(oscAuthClient).DeleteInternetServiceRequest(deleteInternetServiceRequest).Execute()
-	utils.LogAPICall(ctx, "DeleteInternetService", deleteInternetServiceRequest, httpRes, err)
-	return utils.ExtractOAPIError(err, httpRes)
+	err = utils.LogAndExtractError(ctx, "DeleteInternetService", deleteInternetServiceRequest, httpRes, err)
+	return err
 }
 
 // LinkInternetService attaches an internet service to a net.
@@ -93,12 +93,12 @@ func (s *Service) LinkInternetService(ctx context.Context, internetServiceId str
 		var httpRes *http.Response
 		var err error
 		_, httpRes, err = oscApiClient.InternetServiceApi.LinkInternetService(oscAuthClient).LinkInternetServiceRequest(linkInternetServiceRequest).Execute()
-		utils.LogAPICall(ctx, "LinkInternetService", linkInternetServiceRequest, httpRes, err)
+		err = utils.LogAndExtractError(ctx, "LinkInternetService", linkInternetServiceRequest, httpRes, err)
 		if err != nil {
 			if utils.RetryIf(httpRes) {
 				return false, nil
 			}
-			return false, utils.ExtractOAPIError(err, httpRes)
+			return false, err
 		}
 		return true, err
 	}
@@ -119,8 +119,7 @@ func (s *Service) UnlinkInternetService(ctx context.Context, internetServiceId s
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	_, httpRes, err := oscApiClient.InternetServiceApi.UnlinkInternetService(oscAuthClient).UnlinkInternetServiceRequest(unlinkInternetServiceRequest).Execute()
-	utils.LogAPICall(ctx, "UnlinkInternetService", unlinkInternetServiceRequest, httpRes, err)
-	return utils.ExtractOAPIError(err, httpRes)
+	return utils.LogAndExtractError(ctx, "UnlinkInternetService", unlinkInternetServiceRequest, httpRes, err)
 }
 
 // GetInternetService retrieve internet service object using internet service id
@@ -133,9 +132,9 @@ func (s *Service) GetInternetService(ctx context.Context, internetServiceId stri
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	readInternetServicesResponse, httpRes, err := oscApiClient.InternetServiceApi.ReadInternetServices(oscAuthClient).ReadInternetServicesRequest(readInternetServiceRequest).Execute()
-	utils.LogAPICall(ctx, "ReadInternetServices", readInternetServiceRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "ReadInternetServices", readInternetServiceRequest, httpRes, err)
 	if err != nil {
-		return nil, utils.ExtractOAPIError(err, httpRes)
+		return nil, err
 	}
 	internetServices, ok := readInternetServicesResponse.GetInternetServicesOk()
 	if !ok {
@@ -159,9 +158,9 @@ func (s *Service) GetInternetServiceForNet(ctx context.Context, netId string) (*
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	readInternetServicesResponse, httpRes, err := oscApiClient.InternetServiceApi.ReadInternetServices(oscAuthClient).ReadInternetServicesRequest(readInternetServiceRequest).Execute()
-	utils.LogAPICall(ctx, "ReadInternetServices", readInternetServiceRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "ReadInternetServices", readInternetServiceRequest, httpRes, err)
 	if err != nil {
-		return nil, utils.ExtractOAPIError(err, httpRes)
+		return nil, err
 	}
 	internetServices, ok := readInternetServicesResponse.GetInternetServicesOk()
 	if !ok {

--- a/cloud/services/net/natservice.go
+++ b/cloud/services/net/natservice.go
@@ -46,9 +46,9 @@ func (s *Service) CreateNatService(ctx context.Context, publicIpId, subnetId, cl
 	oscAuthClient := s.scope.GetAuth()
 
 	natServiceResponse, httpRes, err := oscApiClient.NatServiceApi.CreateNatService(oscAuthClient).CreateNatServiceRequest(natServiceRequest).Execute()
-	utils.LogAPICall(ctx, "CreateNatService", natServiceRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "CreateNatService", natServiceRequest, httpRes, err)
 	if err != nil {
-		return nil, utils.ExtractOAPIError(err, httpRes)
+		return nil, err
 	}
 	resourceIds := []string{*natServiceResponse.NatService.NatServiceId}
 	natServiceTag := osc.ResourceTag{
@@ -81,8 +81,8 @@ func (s *Service) DeleteNatService(ctx context.Context, natServiceId string) err
 	oscAuthClient := s.scope.GetAuth()
 
 	_, httpRes, err := oscApiClient.NatServiceApi.DeleteNatService(oscAuthClient).DeleteNatServiceRequest(deleteNatServiceRequest).Execute()
-	utils.LogAPICall(ctx, "DeleteNatService", deleteNatServiceRequest, httpRes, err)
-	return utils.ExtractOAPIError(err, httpRes)
+	err = utils.LogAndExtractError(ctx, "DeleteNatService", deleteNatServiceRequest, httpRes, err)
+	return err
 }
 
 // GetNatService retrieve nat service object using nat service id
@@ -95,9 +95,9 @@ func (s *Service) GetNatService(ctx context.Context, natServiceId string) (*osc.
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	readNatServicesResponse, httpRes, err := oscApiClient.NatServiceApi.ReadNatServices(oscAuthClient).ReadNatServicesRequest(readNatServicesRequest).Execute()
-	utils.LogAPICall(ctx, "ReadNatServices", readNatServicesRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "ReadNatServices", readNatServicesRequest, httpRes, err)
 	if err != nil {
-		return nil, utils.ExtractOAPIError(err, httpRes)
+		return nil, err
 	}
 	natServices, ok := readNatServicesResponse.GetNatServicesOk()
 	if !ok {
@@ -121,9 +121,9 @@ func (s *Service) GetNatServiceFromClientToken(ctx context.Context, clientToken 
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	readNatServicesResponse, httpRes, err := oscApiClient.NatServiceApi.ReadNatServices(oscAuthClient).ReadNatServicesRequest(readNatServicesRequest).Execute()
-	utils.LogAPICall(ctx, "ReadNatServices", readNatServicesRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "ReadNatServices", readNatServicesRequest, httpRes, err)
 	if err != nil {
-		return nil, utils.ExtractOAPIError(err, httpRes)
+		return nil, err
 	}
 	natServices, ok := readNatServicesResponse.GetNatServicesOk()
 	if !ok {
@@ -147,13 +147,9 @@ func (s *Service) ListNatServices(ctx context.Context, netId string) ([]osc.NatS
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	readNatServicesResponse, httpRes, err := oscApiClient.NatServiceApi.ReadNatServices(oscAuthClient).ReadNatServicesRequest(readNatServicesRequest).Execute()
-	utils.LogAPICall(ctx, "ReadNatServices", readNatServicesRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "ReadNatServices", readNatServicesRequest, httpRes, err)
 	if err != nil {
-		if httpRes != nil {
-			return nil, utils.ExtractOAPIError(err, httpRes)
-		} else {
-			return nil, err
-		}
+		return nil, err
 	}
 	natServices, ok := readNatServicesResponse.GetNatServicesOk()
 	if !ok {

--- a/cloud/services/net/subnet.go
+++ b/cloud/services/net/subnet.go
@@ -45,9 +45,9 @@ func (s *Service) CreateSubnet(ctx context.Context, spec infrastructurev1beta1.O
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	subnetResponse, httpRes, err := oscApiClient.SubnetApi.CreateSubnet(oscAuthClient).CreateSubnetRequest(subnetRequest).Execute()
-	utils.LogAPICall(ctx, "CreateSubnet", subnetRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "CreateSubnet", subnetRequest, httpRes, err)
 	if err != nil {
-		return nil, utils.ExtractOAPIError(err, httpRes)
+		return nil, err
 	}
 
 	resourceIds := []string{*subnetResponse.Subnet.SubnetId}
@@ -82,8 +82,8 @@ func (s *Service) DeleteSubnet(ctx context.Context, subnetId string) error {
 	oscAuthClient := s.scope.GetAuth()
 
 	_, httpRes, err := oscApiClient.SubnetApi.DeleteSubnet(oscAuthClient).DeleteSubnetRequest(deleteSubnetRequest).Execute()
-	utils.LogAPICall(ctx, "DeleteSubnet", deleteSubnetRequest, httpRes, err)
-	return utils.ExtractOAPIError(err, httpRes)
+	err = utils.LogAndExtractError(ctx, "DeleteSubnet", deleteSubnetRequest, httpRes, err)
+	return err
 }
 
 // GetSubnet retrieve Subnet object from subnet Id
@@ -96,7 +96,7 @@ func (s *Service) GetSubnet(ctx context.Context, subnetId string) (*osc.Subnet, 
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	readSubnetsResponse, httpRes, err := oscApiClient.SubnetApi.ReadSubnets(oscAuthClient).ReadSubnetsRequest(readSubnetsRequest).Execute()
-	utils.LogAPICall(ctx, "ReadSubnets", readSubnetsRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "ReadSubnets", readSubnetsRequest, httpRes, err)
 	if err != nil {
 		return nil, fmt.Errorf("error %w httpres %s", err, httpRes.Status)
 	}
@@ -123,9 +123,9 @@ func (s *Service) GetSubnetFromNet(ctx context.Context, netId, ipRange string) (
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	readSubnetsResponse, httpRes, err := oscApiClient.SubnetApi.ReadSubnets(oscAuthClient).ReadSubnetsRequest(readSubnetsRequest).Execute()
-	utils.LogAPICall(ctx, "ReadSubnets", readSubnetsRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "ReadSubnets", readSubnetsRequest, httpRes, err)
 	if err != nil {
-		return nil, utils.ExtractOAPIError(err, httpRes)
+		return nil, err
 	}
 	subnets, ok := readSubnetsResponse.GetSubnetsOk()
 	if !ok {

--- a/cloud/services/security/publicip.go
+++ b/cloud/services/security/publicip.go
@@ -43,9 +43,9 @@ func (s *Service) CreatePublicIp(ctx context.Context, publicIpName string, clust
 	oscAuthClient := s.scope.GetAuth()
 
 	publicIpResponse, httpRes, err := oscApiClient.PublicIpApi.CreatePublicIp(oscAuthClient).CreatePublicIpRequest(publicIpRequest).Execute()
-	utils.LogAPICall(ctx, "CreatePublicIp", publicIpRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "CreatePublicIp", publicIpRequest, httpRes, err)
 	if err != nil {
-		return nil, utils.ExtractOAPIError(err, httpRes)
+		return nil, err
 	}
 	publicIpTag := osc.ResourceTag{
 		Key:   "Name",
@@ -80,8 +80,8 @@ func (s *Service) DeletePublicIp(ctx context.Context, publicIpId string) error {
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	_, httpRes, err := oscApiClient.PublicIpApi.DeletePublicIp(oscAuthClient).DeletePublicIpRequest(deletePublicIpRequest).Execute()
-	utils.LogAPICall(ctx, "DeletePublicIp", deletePublicIpRequest, httpRes, err)
-	return utils.ExtractOAPIError(err, httpRes)
+	err = utils.LogAndExtractError(ctx, "DeletePublicIp", deletePublicIpRequest, httpRes, err)
+	return err
 }
 
 // GetPublicIp get a public ip object using a public ip id
@@ -96,9 +96,9 @@ func (s *Service) GetPublicIp(ctx context.Context, publicIpId string) (*osc.Publ
 
 	var readPublicIpsResponse osc.ReadPublicIpsResponse
 	readPublicIpsResponse, httpRes, err := oscApiClient.PublicIpApi.ReadPublicIps(oscAuthClient).ReadPublicIpsRequest(readPublicIpRequest).Execute()
-	utils.LogAPICall(ctx, "ReadPublicIps", readPublicIpRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "ReadPublicIps", readPublicIpRequest, httpRes, err)
 	if err != nil {
-		return nil, utils.ExtractOAPIError(err, httpRes)
+		return nil, err
 	}
 	publicIps, ok := readPublicIpsResponse.GetPublicIpsOk()
 	if !ok {
@@ -122,9 +122,9 @@ func (s *Service) GetPublicIpByIp(ctx context.Context, publicIp string) (*osc.Pu
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	readPublicIpsResponse, httpRes, err := oscApiClient.PublicIpApi.ReadPublicIps(oscAuthClient).ReadPublicIpsRequest(readPublicIpRequest).Execute()
-	utils.LogAPICall(ctx, "ReadPublicIps", readPublicIpRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "ReadPublicIps", readPublicIpRequest, httpRes, err)
 	if err != nil {
-		return nil, utils.ExtractOAPIError(err, httpRes)
+		return nil, err
 	}
 	publicIps, ok := readPublicIpsResponse.GetPublicIpsOk()
 	if !ok {
@@ -149,9 +149,9 @@ func (s *Service) ListPublicIpsFromPool(ctx context.Context, pool string) ([]osc
 	oscAuthClient := s.scope.GetAuth()
 
 	readPublicIpsResponse, httpRes, err := oscApiClient.PublicIpApi.ReadPublicIps(oscAuthClient).ReadPublicIpsRequest(readPublicIpRequest).Execute()
-	utils.LogAPICall(ctx, "ReadPublicIps", readPublicIpRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "ReadPublicIps", readPublicIpRequest, httpRes, err)
 	if err != nil {
-		return nil, utils.ExtractOAPIError(err, httpRes)
+		return nil, err
 	}
 	return readPublicIpsResponse.GetPublicIps(), nil
 }
@@ -166,9 +166,9 @@ func (s *Service) ValidatePublicIpIds(ctx context.Context, publicIpIds []string)
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	readPublicIpsResponse, httpRes, err := oscApiClient.PublicIpApi.ReadPublicIps(oscAuthClient).ReadPublicIpsRequest(readPublicIpRequest).Execute()
-	utils.LogAPICall(ctx, "ReadPublicIps", readPublicIpRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "ReadPublicIps", readPublicIpRequest, httpRes, err)
 	if err != nil {
-		return nil, utils.ExtractOAPIError(err, httpRes)
+		return nil, err
 	}
 	var validPublicIpIds []string
 	publicIps, ok := readPublicIpsResponse.GetPublicIpsOk()

--- a/cloud/services/security/route.go
+++ b/cloud/services/security/route.go
@@ -49,9 +49,9 @@ func (s *Service) CreateRouteTable(ctx context.Context, netId string, clusterID 
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	routeTableResponse, httpRes, err := oscApiClient.RouteTableApi.CreateRouteTable(oscAuthClient).CreateRouteTableRequest(routeTableRequest).Execute()
-	utils.LogAPICall(ctx, "CreateRouteTable", routeTableRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "CreateRouteTable", routeTableRequest, httpRes, err)
 	if err != nil {
-		return nil, utils.ExtractOAPIError(err, httpRes)
+		return nil, err
 	}
 	resourceIds := []string{*routeTableResponse.RouteTable.RouteTableId}
 	routeTableTag := osc.ResourceTag{
@@ -100,13 +100,9 @@ func (s *Service) CreateRoute(ctx context.Context, destinationIpRange string, ro
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	routeResponse, httpRes, err := oscApiClient.RouteApi.CreateRoute(oscAuthClient).CreateRouteRequest(routeRequest).Execute()
-	utils.LogAPICall(ctx, "CreateRoute", routeRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "CreateRoute", routeRequest, httpRes, err)
 	if err != nil {
-		if httpRes != nil {
-			return nil, utils.ExtractOAPIError(err, httpRes)
-		} else {
-			return nil, err
-		}
+		return nil, err
 	}
 	route, ok := routeResponse.GetRouteTableOk()
 	if !ok {
@@ -121,8 +117,8 @@ func (s *Service) DeleteRouteTable(ctx context.Context, routeTableId string) err
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	_, httpRes, err := oscApiClient.RouteTableApi.DeleteRouteTable(oscAuthClient).DeleteRouteTableRequest(deleteRouteTableRequest).Execute()
-	utils.LogAPICall(ctx, "DeleteRouteTable", deleteRouteTableRequest, httpRes, err)
-	return utils.ExtractOAPIError(err, httpRes)
+	err = utils.LogAndExtractError(ctx, "DeleteRouteTable", deleteRouteTableRequest, httpRes, err)
+	return err
 }
 
 // DeleteRoute delete the route associated with the routetable
@@ -134,8 +130,8 @@ func (s *Service) DeleteRoute(ctx context.Context, destinationIpRange string, ro
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	_, httpRes, err := oscApiClient.RouteApi.DeleteRoute(oscAuthClient).DeleteRouteRequest(deleteRouteRequest).Execute()
-	utils.LogAPICall(ctx, "DeleteRoute", deleteRouteRequest, httpRes, err)
-	return utils.ExtractOAPIError(err, httpRes)
+	err = utils.LogAndExtractError(ctx, "DeleteRoute", deleteRouteRequest, httpRes, err)
+	return err
 }
 
 // GetRouteTable retrieve routetable object from the route table id
@@ -148,13 +144,9 @@ func (s *Service) GetRouteTable(ctx context.Context, routeTableId []string) (*os
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	readRouteTablesResponse, httpRes, err := oscApiClient.RouteTableApi.ReadRouteTables(oscAuthClient).ReadRouteTablesRequest(readRouteTableRequest).Execute()
-	utils.LogAPICall(ctx, "ReadRouteTables", readRouteTableRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "ReadRouteTables", readRouteTableRequest, httpRes, err)
 	if err != nil {
-		if httpRes != nil {
-			return nil, utils.ExtractOAPIError(err, httpRes)
-		} else {
-			return nil, err
-		}
+		return nil, err
 	}
 	var routetable []osc.RouteTable
 	routetables, ok := readRouteTablesResponse.GetRouteTablesOk()
@@ -193,13 +185,9 @@ func (s *Service) GetRouteTableFromRoute(ctx context.Context, routeTableId strin
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	readRouteResponse, httpRes, err := oscApiClient.RouteTableApi.ReadRouteTables(oscAuthClient).ReadRouteTablesRequest(readRouteRequest).Execute()
-	utils.LogAPICall(ctx, "ReadRouteTables", readRouteRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "ReadRouteTables", readRouteRequest, httpRes, err)
 	if err != nil {
-		if httpRes != nil {
-			return nil, utils.ExtractOAPIError(err, httpRes)
-		} else {
-			return nil, err
-		}
+		return nil, err
 	}
 	routetables, ok := readRouteResponse.GetRouteTablesOk()
 	if !ok {
@@ -226,12 +214,12 @@ func (s *Service) LinkRouteTable(ctx context.Context, routeTableId string, subne
 		var httpRes *http.Response
 		var err error
 		linkRouteTableResponse, httpRes, err = oscApiClient.RouteTableApi.LinkRouteTable(oscAuthClient).LinkRouteTableRequest(linkRouteTableRequest).Execute()
-		utils.LogAPICall(ctx, "LinkRouteTable", linkRouteTableRequest, httpRes, err)
+		err = utils.LogAndExtractError(ctx, "LinkRouteTable", linkRouteTableRequest, httpRes, err)
 		if err != nil {
 			if utils.RetryIf(httpRes) {
 				return false, nil
 			}
-			return false, utils.ExtractOAPIError(err, httpRes)
+			return false, err
 		}
 		return true, err
 	}
@@ -256,8 +244,8 @@ func (s *Service) UnlinkRouteTable(ctx context.Context, linkRouteTableId string)
 	oscAuthClient := s.scope.GetAuth()
 
 	_, httpRes, err := oscApiClient.RouteTableApi.UnlinkRouteTable(oscAuthClient).UnlinkRouteTableRequest(unlinkRouteTableRequest).Execute()
-	utils.LogAPICall(ctx, "UnlinkRouteTable", unlinkRouteTableRequest, httpRes, err)
-	return utils.ExtractOAPIError(err, httpRes)
+	err = utils.LogAndExtractError(ctx, "UnlinkRouteTable", unlinkRouteTableRequest, httpRes, err)
+	return err
 }
 
 // GetRouteTablesFromNet returns all non main route tables present in a net.
@@ -271,13 +259,9 @@ func (s *Service) GetRouteTablesFromNet(ctx context.Context, netId string) ([]os
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	readRouteTablesResponse, httpRes, err := oscApiClient.RouteTableApi.ReadRouteTables(oscAuthClient).ReadRouteTablesRequest(readRouteTablesRequest).Execute()
-	utils.LogAPICall(ctx, "ReadRouteTables", readRouteTablesRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "ReadRouteTables", readRouteTablesRequest, httpRes, err)
 	if err != nil {
-		if httpRes != nil {
-			return nil, utils.ExtractOAPIError(err, httpRes)
-		} else {
-			return nil, err
-		}
+		return nil, err
 	}
 	return readRouteTablesResponse.GetRouteTables(), nil
 }

--- a/cloud/services/security/securitygroup.go
+++ b/cloud/services/security/securitygroup.go
@@ -51,9 +51,9 @@ func (s *Service) CreateSecurityGroup(ctx context.Context, netId string, cluster
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	securityGroupResponse, httpRes, err := oscApiClient.SecurityGroupApi.CreateSecurityGroup(oscAuthClient).CreateSecurityGroupRequest(securityGroupRequest).Execute()
-	utils.LogAPICall(ctx, "CreateSecurityGroup", securityGroupRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "CreateSecurityGroup", securityGroupRequest, httpRes, err)
 	if err != nil {
-		return nil, utils.ExtractOAPIError(err, httpRes)
+		return nil, err
 	}
 	securityGroup, ok := securityGroupResponse.GetSecurityGroupOk()
 	if !ok {
@@ -122,11 +122,9 @@ func (s *Service) CreateSecurityGroupRule(ctx context.Context, securityGroupId s
 	oscAuthClient := s.scope.GetAuth()
 
 	securityGroupRuleResponse, httpRes, err := oscApiClient.SecurityGroupRuleApi.CreateSecurityGroupRule(oscAuthClient).CreateSecurityGroupRuleRequest(createSecurityGroupRuleRequest).Execute()
-	utils.LogAPICall(ctx, "CreateSecurityGroupRule", createSecurityGroupRuleRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "CreateSecurityGroupRule", createSecurityGroupRuleRequest, httpRes, err)
 	if err != nil {
-		if httpRes == nil || httpRes.StatusCode != 409 {
-			return nil, utils.ExtractOAPIError(err, httpRes)
-		}
+		return nil, err
 	}
 	securityGroupRule, ok := securityGroupRuleResponse.GetSecurityGroupOk()
 	if !ok {
@@ -168,8 +166,8 @@ func (s *Service) DeleteSecurityGroupRule(ctx context.Context, securityGroupId s
 	oscAuthClient := s.scope.GetAuth()
 
 	_, httpRes, err := oscApiClient.SecurityGroupRuleApi.DeleteSecurityGroupRule(oscAuthClient).DeleteSecurityGroupRuleRequest(deleteSecurityGroupRuleRequest).Execute()
-	utils.LogAPICall(ctx, "DeleteSecurityGroupRule", deleteSecurityGroupRuleRequest, httpRes, err)
-	return utils.ExtractOAPIError(err, httpRes)
+	err = utils.LogAndExtractError(ctx, "DeleteSecurityGroupRule", deleteSecurityGroupRuleRequest, httpRes, err)
+	return err
 }
 
 // DeleteSecurityGroup delete the securitygroup associated with the net
@@ -178,8 +176,8 @@ func (s *Service) DeleteSecurityGroup(ctx context.Context, securityGroupId strin
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	_, httpRes, err := oscApiClient.SecurityGroupApi.DeleteSecurityGroup(oscAuthClient).DeleteSecurityGroupRequest(deleteSecurityGroupRequest).Execute()
-	utils.LogAPICall(ctx, "DeleteSecurityGroup", deleteSecurityGroupRequest, httpRes, err)
-	return utils.ExtractOAPIError(err, httpRes)
+	err = utils.LogAndExtractError(ctx, "DeleteSecurityGroup", deleteSecurityGroupRequest, httpRes, err)
+	return err
 }
 
 // GetSecurityGroup retrieve security group object from the security group id
@@ -192,9 +190,9 @@ func (s *Service) GetSecurityGroup(ctx context.Context, securityGroupId string) 
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	readSecurityGroupsResponse, httpRes, err := oscApiClient.SecurityGroupApi.ReadSecurityGroups(oscAuthClient).ReadSecurityGroupsRequest(readSecurityGroupRequest).Execute()
-	utils.LogAPICall(ctx, "ReadSecurityGroups", readSecurityGroupRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "ReadSecurityGroups", readSecurityGroupRequest, httpRes, err)
 	if err != nil {
-		return nil, utils.ExtractOAPIError(err, httpRes)
+		return nil, err
 	}
 	securitygroups, ok := readSecurityGroupsResponse.GetSecurityGroupsOk()
 	if !ok {
@@ -218,9 +216,9 @@ func (s *Service) GetSecurityGroupFromName(ctx context.Context, name string) (*o
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	readSecurityGroupsResponse, httpRes, err := oscApiClient.SecurityGroupApi.ReadSecurityGroups(oscAuthClient).ReadSecurityGroupsRequest(readSecurityGroupRequest).Execute()
-	utils.LogAPICall(ctx, "ReadSecurityGroups", readSecurityGroupRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "ReadSecurityGroups", readSecurityGroupRequest, httpRes, err)
 	if err != nil {
-		return nil, utils.ExtractOAPIError(err, httpRes)
+		return nil, err
 	}
 	securitygroups, ok := readSecurityGroupsResponse.GetSecurityGroupsOk()
 	if !ok {
@@ -282,9 +280,9 @@ func (s *Service) SecurityGroupHasRule(ctx context.Context, securityGroupId stri
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	readSecurityGroupRulesResponse, httpRes, err := oscApiClient.SecurityGroupApi.ReadSecurityGroups(oscAuthClient).ReadSecurityGroupsRequest(readSecurityGroupRuleRequest).Execute()
-	utils.LogAPICall(ctx, "ReadSecurityGroups", readSecurityGroupRuleRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "ReadSecurityGroups", readSecurityGroupRuleRequest, httpRes, err)
 	if err != nil {
-		return false, utils.ExtractOAPIError(err, httpRes)
+		return false, err
 	}
 	securityGroups, ok := readSecurityGroupRulesResponse.GetSecurityGroupsOk()
 	if !ok {
@@ -303,9 +301,9 @@ func (s *Service) GetSecurityGroupsFromNet(ctx context.Context, netId string) ([
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	readSecurityGroupsResponse, httpRes, err := oscApiClient.SecurityGroupApi.ReadSecurityGroups(oscAuthClient).ReadSecurityGroupsRequest(readSecurityGroupRequest).Execute()
-	utils.LogAPICall(ctx, "ReadSecurityGroups", readSecurityGroupRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "ReadSecurityGroups", readSecurityGroupRequest, httpRes, err)
 	if err != nil {
-		return nil, utils.ExtractOAPIError(err, httpRes)
+		return nil, err
 	}
 	return readSecurityGroupsResponse.GetSecurityGroups(), nil
 }

--- a/cloud/tag/tag.go
+++ b/cloud/tag/tag.go
@@ -57,13 +57,13 @@ type OscTagInterface interface {
 func AddTag(ctx context.Context, createTagRequest osc.CreateTagsRequest, resourceIds []string, api *osc.APIClient, auth context.Context) error {
 	addTagNameCallBack := func() (bool, error) {
 		_, httpRes, err := api.TagApi.CreateTags(auth).CreateTagsRequest(createTagRequest).Execute()
-		utils.LogAPICall(ctx, "CreateTags", createTagRequest, httpRes, err)
+		err = utils.LogAndExtractError(ctx, "CreateTags", createTagRequest, httpRes, err)
 		if err != nil {
 			// we wish to retry on TCP errors, but not on 400 errors.
 			if utils.RetryIf(httpRes) || httpRes == nil {
 				return false, nil
 			}
-			return false, utils.ExtractOAPIError(err, httpRes)
+			return false, err
 		}
 		return true, nil
 	}
@@ -83,7 +83,7 @@ func (s *Service) ReadTag(ctx context.Context, rsrcType ResourceType, key, value
 	oscApiClient := s.scope.GetApi()
 	oscAuthClient := s.scope.GetAuth()
 	readTagsResponse, httpRes, err := oscApiClient.TagApi.ReadTags(oscAuthClient).ReadTagsRequest(readTagsRequest).Execute()
-	utils.LogAPICall(ctx, "ReadTags", readTagsRequest, httpRes, err)
+	err = utils.LogAndExtractError(ctx, "ReadTags", readTagsRequest, httpRes, err)
 	if err != nil {
 		if httpRes != nil {
 			fmt.Printf("Error with http result %s", httpRes.Status)

--- a/cloud/utils/errors_test.go
+++ b/cloud/utils/errors_test.go
@@ -1,0 +1,33 @@
+package utils_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/outscale/cluster-api-provider-outscale/cloud/utils"
+	"github.com/outscale/osc-sdk-go/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractOAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(400)
+		fmt.Fprintln(w, `{"Errors":[{"Type":"InternalError","Details":"Outscale faced an internal error while processing your request","Code":"2000"}],"ResponseContext":{"RequestId":"7c0d8260-0fe2-4acd-af4a-31dc2245eaf8"}}`)
+	}))
+	defer srv.Close()
+	cl := osc.NewAPIClient(&osc.Configuration{
+		DefaultHeader:    make(map[string]string),
+		Servers:          osc.ServerConfigurations{{URL: srv.URL}},
+		OperationServers: map[string]osc.ServerConfigurations{},
+	})
+	ctx := context.TODO()
+	_, httpRes, err := cl.NetApi.CreateNet(ctx).CreateNetRequest(osc.CreateNetRequest{}).Execute()
+	require.Error(t, err)
+	err = utils.LogAndExtractError(ctx, "CreateNet", osc.CreateNetRequest{}, httpRes, err)
+	assert.EqualError(t, err, "2000/InternalError (Outscale faced an internal error while processing your request)")
+}


### PR DESCRIPTION
HTTP 409 errors were not properly decoded, and the corresponding error code was not properly logged/stored in status.