### PR TITLE
🔊 logs: replace zap by klog

### DIFF
--- a/capm.yaml
+++ b/capm.yaml
@@ -2351,7 +2351,7 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
-        - --zap-log-level=10
+        - -v5
         command:
         - /manager
         env:

--- a/config/default/manager_args.yaml
+++ b/config/default/manager_args.yaml
@@ -14,3 +14,4 @@ spec:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
+        - "-v5"

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -32,4 +32,4 @@ spec:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
-        - "--zap-log-level=10"
+        - "-v5"

--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,6 @@ require (
 	sigs.k8s.io/controller-runtime v0.18.7
 )
 
-require go.uber.org/automaxprocs v1.6.0 // indirect
-
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/BurntSushi/toml v1.4.0 // indirect
@@ -106,7 +104,7 @@ require (
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/spf13/cobra v1.8.1 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
@@ -119,6 +117,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.22.0 // indirect
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
+	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
@@ -145,7 +144,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.30.12
 	k8s.io/apiserver v0.30.12 // indirect
 	k8s.io/cluster-bootstrap v0.30.3 // indirect
-	k8s.io/component-base v0.30.12 // indirect
+	k8s.io/component-base v0.30.12
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.0 // indirect

--- a/helm/clusterapioutscale/README.md
+++ b/helm/clusterapioutscale/README.md
@@ -14,26 +14,28 @@ Deploy Outscale Cluster API. Please look at deploy.md
 | deployment.annotations | object | `{"kubectl.kubernetes.io/default-container":"manager"}` | Annotations to set on pods |
 | deployment.backoffDuration | string | `"1"` | Initial duraction of backoff |
 | deployment.backoffFactor | string | `"1.5"` | Factor multiplied by Duration for each iteration |
-| deployment.backoffSteps | string | `"20"` | Remaining number of iterations in which the duration parameter may change |
+| deployment.backoffSteps | string | `"10"` | Remaining number of iterations in which the duration parameter may change |
 | deployment.enable | bool | `true` | Enable deployment |
 | deployment.image | string | `"registry.hub.docker.com/outscale/cluster-api-outscale-controllers"` | Outscale provider image |
 | deployment.imagePullPolicy | string | `"IfNotPresent"` | ImagePullPolcy to use (IfNotPresent, Never, Always) |
 | deployment.imagePullSecrets | list | `[]` | Specify image pull secrets |
-| deployment.imageTag | string | `"v0.1.0"` | Outscale provider image tag |
+| deployment.imageTag | string | `"v0.4.0"` | Outscale provider image tag |
 | deployment.labels | object | `nil` | Labels to set on pods |
+| deployment.logging.format | string | `"text"` | Logging format (text or json) |
 | deployment.proxyImage | string | `"gcr.io/kubebuilder/kube-rbac-proxy"` | Proxy image |
 | deployment.proxyImageTag | string | `"v0.8.0"` | Proxy image tag |
-| deployment.proxyResources | object | `{"cpu":{"limits":"200m","requests":"100m"},"memory":{"limits":"30Mi","requests":"20Mi"}}` | Proxy container resource limit/requests (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
-| deployment.proxyResources.cpu.limits | string | `"200m"` | Container proxy cpu limits |
+| deployment.proxyResources | object | `{"cpu":{"limits":"100m","requests":"100m"},"memory":{"limits":"64Mi","requests":"64Mi"}}` | Proxy container resource limit/requests (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| deployment.proxyResources.cpu.limits | string | `"100m"` | Container proxy cpu limits |
 | deployment.proxyResources.cpu.requests | string | `"100m"` | Container proxy cpu requests |
-| deployment.proxyResources.memory.limits | string | `"30Mi"` | Container proxy memory limits |
-| deployment.proxyResources.memory.requests | string | `"20Mi"` | Container proxy memory requests |
+| deployment.proxyResources.memory.limits | string | `"64Mi"` | Container proxy memory limits |
+| deployment.proxyResources.memory.requests | string | `"64Mi"` | Container proxy memory requests |
 | deployment.replicaCount | int | `1` | Number of replicas |
-| deployment.resources | object | `{"cpu":{"limits":"200m","requests":"100m"},"memory":{"limits":"30Mi","requests":"20Mi"}}` | Container resource limit/requests (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
-| deployment.resources.cpu.limits | string | `"200m"` | Container cpu limts |
+| deployment.resources | object | `{"cpu":{"limits":"100m","requests":"100m"},"memory":{"limits":"128Mi","requests":"128Mi"}}` | Container resource limit/requests (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| deployment.resources.cpu.limits | string | `"100m"` | Container cpu limts |
 | deployment.resources.cpu.requests | string | `"100m"` | Container cpu requests |
-| deployment.resources.memory.limits | string | `"30Mi"` | Container memory limits |
-| deployment.resources.memory.requests | string | `"20Mi"` | Container memory requests |
+| deployment.resources.memory.limits | string | `"128Mi"` | Container memory limits |
+| deployment.resources.memory.requests | string | `"128Mi"` | Container memory requests |
+| deployment.secretName | string | `"cluster-api-provider-outscale"` | Name of the secret to find access_key/secret_key/region used by the provider |
 | deployment.securityContext | object | `{"allowPrivilegeEscalation":false}` | Additional securityContext to add |
 | deployment.verbosity | int | `5` | Verbosity level of plugin |
 | deployment.watchFilter | string | `""` |  |

--- a/helm/clusterapioutscale/templates/deployment.yaml
+++ b/helm/clusterapioutscale/templates/deployment.yaml
@@ -55,7 +55,8 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
-        - --zap-log-level={{ .verbosity }}
+        - -v{{ .verbosity }}
+        - --logging-format={{ .logging.format }}
         {{- if .watchFilter }}
         - --watch-filter={{ .watchFilter }}
         {{- end}}

--- a/helm/clusterapioutscale/values.yaml
+++ b/helm/clusterapioutscale/values.yaml
@@ -61,6 +61,10 @@ deployment:
       limits: 100m
   # -- Name of the secret to find access_key/secret_key/region used by the provider
   secretName: cluster-api-provider-outscale
+  logging:
+    # -- Logging format (text or json)
+    format: text
+
 crd:
   # -- enable crd
   enable: True


### PR DESCRIPTION
This PR replaces zap with the standard k8s logger (klog), using the standard flags.

Default format is now text, but may be switched to json by starting the manager with `-logging-format=json`