### PR TITLE
✨ feat: add service roles for CCM load balancers

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -24,11 +24,13 @@ import (
 type OscRole string
 
 const (
-	RoleControlPlane OscRole = "controlplane"
-	RoleWorker       OscRole = "worker"
-	RoleLoadBalancer OscRole = "loadbalancer"
-	RoleBastion      OscRole = "bastion"
-	RoleNat          OscRole = "nat"
+	RoleControlPlane    OscRole = "controlplane"
+	RoleWorker          OscRole = "worker"
+	RoleLoadBalancer    OscRole = "loadbalancer"
+	RoleBastion         OscRole = "bastion"
+	RoleNat             OscRole = "nat"
+	RoleService         OscRole = "service"
+	RoleInternalService OscRole = "service.internal"
 )
 
 type OscNode struct {

--- a/cloud/utils/utils.go
+++ b/cloud/utils/utils.go
@@ -40,11 +40,21 @@ func ConvertsTagsToUserDataOutscaleSection(tags map[string]string) string {
 
 func RoleTags(roles []infrastructurev1beta1.OscRole) []osc.ResourceTag {
 	rs := make([]osc.ResourceTag, 0, len(roles))
-	for i := range roles {
+	for _, role := range roles {
 		rs = append(rs, osc.ResourceTag{
-			Key:   "OscK8sRole/" + string(roles[i]),
-			Value: "true",
+			Key: "OscK8sRole/" + string(role),
 		})
+		// CCM 0.4 compatibility.
+		switch role {
+		case infrastructurev1beta1.RoleService:
+			rs = append(rs, osc.ResourceTag{
+				Key: "kubernetes.io/role/elb",
+			})
+		case infrastructurev1beta1.RoleInternalService:
+			rs = append(rs, osc.ResourceTag{
+				Key: "kubernetes.io/role/internal-elb",
+			})
+		}
 	}
 	return rs
 }

--- a/docs/src/topics/config-cluster.md
+++ b/docs/src/topics/config-cluster.md
@@ -12,11 +12,13 @@ An osccluster resource defines:
 * a load-balancer for the kubernetes API.
 
 Roles define the role(s) a network resource may have:
-* `loadbalancer`,
-* `nat`,
-* `bastion`,
-* `controlplane`,
-* `worker`.
+* `loadbalancer` (kube API load-balancer),
+* `nat` (NAT services),
+* `bastion` (Bastion),
+* `controlplane` (control plane nodes),
+* `worker` (worker nodes),
+* `service` (public service load-balancers),
+* `service.internal` (internal service load-balancers).
 
 Resources may be either automatically or manually created.
 
@@ -44,6 +46,16 @@ When using roles:
 * there must be a single subnet having the loadbalancer and bastion roles,
 * there must be one subnet with the controlplane or worker role per subregion where the corresponding nodes will be deployed,
 * there must be one subnet with the nat role per subregion in the cluster.
+
+### Service load-balancers
+
+When a service of type `LoadBalancer` is created, the CCM will configure a new LBU.
+
+If the service is configured as internal, the CCM will fetch a subnet having the `service.internal` role.
+Otherwise, a subnet having the `service` role is used.
+If no subnet is found, the CCM fetches the subnet with the `loadbalancer` role.
+
+If the lo
 
 ### Automatic mode
 


### PR DESCRIPTION
Add new service roles to define the subnet to use for loadbalancers (public or internal).

Additional roles are configured for CCM 0.4 compatibility.

Refs #594
