### PR TITLE
🐛 fix: when ipProtocol=-1, fromPortRange and toPortRange are stored as -1

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -382,6 +382,20 @@ func (sgr *OscSecurityGroupRule) GetIpRanges() []string {
 	return nil
 }
 
+func (sgr *OscSecurityGroupRule) GetFromPortRange() int32 {
+	if sgr.IpProtocol == "-1" {
+		return -1
+	}
+	return sgr.FromPortRange
+}
+
+func (sgr *OscSecurityGroupRule) GetToPortRange() int32 {
+	if sgr.IpProtocol == "-1" {
+		return -1
+	}
+	return sgr.ToPortRange
+}
+
 // Map between resourceId and resourceName (tag Name with cluster UID)
 type OscResourceReference struct {
 	ResourceMap map[string]string `json:"resourceMap,omitempty"`

--- a/controllers/osccluster_securitygroup_controller.go
+++ b/controllers/osccluster_securitygroup_controller.go
@@ -45,8 +45,8 @@ func (r *OscClusterReconciler) reconcileSecurityGroupAddRules(ctx context.Contex
 		}
 		flow := securityGroupRuleSpec.Flow
 		protocol := securityGroupRuleSpec.IpProtocol
-		fromPort := securityGroupRuleSpec.FromPortRange
-		toPort := securityGroupRuleSpec.ToPortRange
+		fromPort := securityGroupRuleSpec.GetFromPortRange()
+		toPort := securityGroupRuleSpec.GetToPortRange()
 		var existingRanges []string
 		for _, rule := range rules {
 			if rule.GetFromPortRange() != fromPort || rule.GetToPortRange() != toPort || rule.GetIpProtocol() != protocol {
@@ -82,7 +82,9 @@ func (r *OscClusterReconciler) reconcileSecurityGroupDeleteRules(ctx context.Con
 			}
 			var okRanges []string
 			for _, spec := range securityGroupRulesSpec {
-				if flow != spec.Flow || rule.GetFromPortRange() != spec.FromPortRange || rule.GetToPortRange() != spec.ToPortRange || rule.GetIpProtocol() != spec.IpProtocol {
+				if flow != spec.Flow ||
+					rule.GetFromPortRange() != spec.GetFromPortRange() || rule.GetToPortRange() != spec.GetToPortRange() ||
+					rule.GetIpProtocol() != spec.IpProtocol {
 					continue
 				}
 				okRanges = append(okRanges, spec.GetIpRanges()...)


### PR DESCRIPTION
Fixes #599