### PR TITLE
🐛 fix(OscMachine): CCM tags were not set if a node from another cluster shared the same private IP

### DIFF
--- a/cloud/services/compute/mock_compute/vm_mock.go
+++ b/cloud/services/compute/mock_compute/vm_mock.go
@@ -43,18 +43,18 @@ func (m *MockOscVmInterface) EXPECT() *MockOscVmInterfaceMockRecorder {
 	return m.recorder
 }
 
-// AddCcmTag mocks base method.
-func (m *MockOscVmInterface) AddCcmTag(ctx context.Context, clusterName, hostname, vmId string) error {
+// AddCCMTags mocks base method.
+func (m *MockOscVmInterface) AddCCMTags(ctx context.Context, clusterName, hostname, vmId string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddCcmTag", ctx, clusterName, hostname, vmId)
+	ret := m.ctrl.Call(m, "AddCCMTags", ctx, clusterName, hostname, vmId)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// AddCcmTag indicates an expected call of AddCcmTag.
-func (mr *MockOscVmInterfaceMockRecorder) AddCcmTag(ctx, clusterName, hostname, vmId any) *gomock.Call {
+// AddCCMTags indicates an expected call of AddCCMTags.
+func (mr *MockOscVmInterfaceMockRecorder) AddCCMTags(ctx, clusterName, hostname, vmId any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddCcmTag", reflect.TypeOf((*MockOscVmInterface)(nil).AddCcmTag), ctx, clusterName, hostname, vmId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddCCMTags", reflect.TypeOf((*MockOscVmInterface)(nil).AddCCMTags), ctx, clusterName, hostname, vmId)
 }
 
 // CreateVm mocks base method.

--- a/controllers/oscmachine_vm_controller.go
+++ b/controllers/oscmachine_vm_controller.go
@@ -27,7 +27,6 @@ import (
 	infrastructurev1beta1 "github.com/outscale/cluster-api-provider-outscale/api/v1beta1"
 	"github.com/outscale/cluster-api-provider-outscale/cloud/scope"
 	"github.com/outscale/cluster-api-provider-outscale/cloud/services/compute"
-	tag "github.com/outscale/cluster-api-provider-outscale/cloud/tag"
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -179,13 +178,9 @@ func (r *OscMachineReconciler) reconcileVm(ctx context.Context, clusterScope *sc
 		machineScope.SetFailureDomain(vm.Placement.GetSubregionName())
 	}
 
-	tag, err := r.Cloud.Tag(ctx, *clusterScope).ReadTag(ctx, tag.VmResourceType, "OscK8sNodeName", *privateDnsName)
-	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("cannot get tag: %w", err)
-	}
-	if tag == nil {
+	if !compute.HasCCMTags(vm) {
 		log.V(2).Info("Adding CCM tags")
-		err = r.Cloud.VM(ctx, *clusterScope).AddCcmTag(ctx, clusterScope.GetUID(), *privateDnsName, vm.GetVmId())
+		err = r.Cloud.VM(ctx, *clusterScope).AddCCMTags(ctx, clusterScope.GetUID(), *privateDnsName, vm.GetVmId())
 		if err != nil {
 			return reconcile.Result{}, fmt.Errorf("cannot add ccm tag: %w", err)
 		}


### PR DESCRIPTION
## ✨ Description

The previous code only set CCM tags if no other node shared the same node name (= same private IP).

Fixes: #614

---

## 🏷️ Type of Change

- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI change
- [ ] 🔒 Security fix
- [ ] 📦 Dependency update
- [ ] 💥 API change
- [ ] 🧊 Deprecation
- [ ] 🕳️ Regression fix
- [ ] Other: <!-- specify -->

---

## 🧪 How Has This Been Tested?

- [ ] Manual testing
- [X] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

---

## ✅ Checklist

* [X] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [X] I have added tests or explained why they are not needed
* [X] I have updated relevant documentation (README, examples, etc.)
* [X] I have followed the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [X] My commits include appropriate [Gitmoji](https://gitmoji.dev/)
* [X] My commits are squashed

---

## 📎 Additional Context

---

## 🙏 Reviewer Notes
