### PR TITLE
👷 ci: switch back to subregion a

### DIFF
--- a/github_actions/deploy_cluster/main.sh
+++ b/github_actions/deploy_cluster/main.sh
@@ -42,7 +42,7 @@ kubeconfig=`/.venv/bin/oks-cli cluster kubeconfig --cluster-name $cluster_name -
 export KUBECONFIG=$kubeconfig
 
 # clusterctl
-export OSC_SUBREGION_NAME=${OSC_REGION}b
+export OSC_SUBREGION_NAME=${OSC_REGION}a
 export OSC_KEYPAIR_NAME=cluster-api
 export OSC_IOPS=1000
 export OSC_VOLUME_SIZE=30


### PR DESCRIPTION
## ✨ Description

Some E2E tests in other projects assume that the nodes are deployed in subregion a.

We switch back to a to stop breaking those tests.

---

## 🏷️ Type of Change

<!-- Add X in the box below -->

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [X] 🔧 Build or CI change
- [ ] 🔒 Security fix
- [ ] 📦 Dependency update
- [ ] 💥 API change
- [ ] 🧊 Deprecation
- [ ] 🕳️ Regression fix
- [ ] Other: <!-- specify -->

---

## 🧪 How Has This Been Tested?

- [ ] Manual testing
- [ ] Unit tests
- [X] E2E tests
- [ ] Not tested yet

---

## ✅ Checklist

* [X] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [X] I have added tests or explained why they are not needed
* [X] I have updated relevant documentation (README, examples, etc.)
* [X] I have followed the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [X] My commits include appropriate [Gitmoji](https://gitmoji.dev/)
* [X] My commits are squashed

---

## 📎 Additional Context

---

## 🙏 Reviewer Notes
