### PR TITLE
🐛 fix(security groups): allowFromIPRanges/allowToIPRanges should not change the security groups spec

### DIFF
--- a/controllers/osccluster_controller_test.go
+++ b/controllers/osccluster_controller_test.go
@@ -711,8 +711,8 @@ func TestReconcileOSCCluster_Create(t *testing.T) {
 				mockGetSecurityGroupFromName("test-cluster-api-bastion-9e1db9c4-bf0a-4583-8999-203ec002c520", nil),
 				mockCreateSecurityGroup("vpc-foo", "9e1db9c4-bf0a-4583-8999-203ec002c520", "test-cluster-api-bastion-9e1db9c4-bf0a-4583-8999-203ec002c520",
 					"", "", []infrastructurev1beta1.OscRole{infrastructurev1beta1.RoleBastion}, "sg-bastion"),
-				mockCreateSecurityGroupRule("sg-bastion", "Inbound", "tcp", "1.2.3.4/32", 6443, 6443),
-				mockCreateSecurityGroupRule("sg-bastion", "Inbound", "tcp", "2.3.4.5/32", 6443, 6443),
+				mockCreateSecurityGroupRule("sg-bastion", "Inbound", "tcp", "1.2.3.4/32", 22, 22),
+				mockCreateSecurityGroupRule("sg-bastion", "Inbound", "tcp", "2.3.4.5/32", 22, 22),
 				mockCreateSecurityGroupRule("sg-bastion", "Outbound", "-1", "3.4.5.6/32", -1, -1),
 				mockCreateSecurityGroupRule("sg-bastion", "Outbound", "-1", "5.6.7.8/32", -1, -1),
 


### PR DESCRIPTION
## Description

When the security groups are defined in the spec, allowFromIPRanges/allowToIPRanges would add entries to the spec at each reconciliation, resulting in multiple/infinite duplicates of the allowFromIPRanges/allowToIPRanges rules.

The allowFromIPRanges/allowToIPRanges rules should not be added to the spec.

This also fixes a bug where allowFromIPRanges would allow traffic on port 6443 to the bastion instead of 22.

cc @pli01 

## Type of Change

Please check the relevant option(s):

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [x] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
