### PR TITLE
⚰️ cleanup: remove runc in templates, already installed by image-builder

### DIFF
--- a/example/cluster-machine-template-bastion.yaml
+++ b/example/cluster-machine-template-bastion.yaml
@@ -128,24 +128,12 @@ metadata:
 spec:
   template:
     spec:
-      files:
-      - content: |
-          #!/bin/sh
-
-          curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-          chmod +x /tmp/runc.amd64
-          cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-        owner: root:root
-        path: /tmp/set_runc.sh
-        permissions: "0744"
       joinConfiguration:
         nodeRegistration:
           name: "{{ ds.meta_data.local_hostname }}"
           kubeletExtraArgs:
             cloud-provider: external
             provider-id: osc://'{{ ds.meta_data.instance_id }}'
-      preKubeadmCommands:
-        - sh /tmp/set_runc.sh
 ---
 kind: KubeadmControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -166,20 +154,9 @@ spec:
           cloud-provider: external
           provider-id: osc://'{{ ds.meta_data.instance_id }}'
         name: '{{ ds.meta_data.local_hostname }}'
-    files:
-    - content: |
-        #!/bin/sh
-        curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-        chmod +x /tmp/runc.amd64
-        cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-      owner: root:root
-      path: /tmp/set_runc.sh
-      permissions: "0744"
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
           provider-id: osc://'{{ ds.meta_data.instance_id }}'
-    preKubeadmCommands:
-      - sh /tmp/set_runc.sh
   version: "1.28.5"

--- a/example/cluster-machine-template-default.yaml
+++ b/example/cluster-machine-template-default.yaml
@@ -105,24 +105,12 @@ metadata:
 spec:
   template:
     spec:
-      files:
-      - content: |
-          #!/bin/bash
-
-          curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-          chmod +x /tmp/runc.amd64
-          \cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-        owner: root:root
-        path: /tmp/set_runc.sh
-        permissions: "0744"
       joinConfiguration:
         nodeRegistration:
           name: "{{ ds.meta_data.local_hostname }}"
           kubeletExtraArgs:
             cloud-provider: external
             provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-      preKubeadmCommands:
-        - sh /tmp/set_runc.sh
 ---
 kind: KubeadmControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -143,19 +131,8 @@ spec:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
         name: '{{ ds.meta_data.local_hostname }}'
-    files:
-    - content: |
-        #!/bin/bash
-        curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-        chmod +x /tmp/runc.amd64
-        \cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-      owner: root:root
-      path: /tmp/set_runc.sh
-      permissions: "0744"
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-    preKubeadmCommands:
-      - sh /tmp/set_runc.sh
   version: "1.22.11"

--- a/example/cluster-machine-template-multi-az.yaml
+++ b/example/cluster-machine-template-multi-az.yaml
@@ -80,23 +80,12 @@ spec:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
         name: '{{ ds.meta_data.local_hostname }}'
-    files:
-    - content: |
-        #!/bin/sh
-        curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-        chmod +x /tmp/runc.amd64
-        cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-      owner: root:root
-      path: /tmp/set_runc.sh
-      permissions: "0744"
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
         name: '{{ ds.meta_data.local_hostname }}'
-    preKubeadmCommands:
-      - sh /tmp/set_runc.sh
   version: "1.29.1"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -145,23 +134,12 @@ metadata:
 spec:
   template:
     spec:
-      files:
-      - content: |
-          #!/bin/sh
-          curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-          chmod +x /tmp/runc.amd64
-          cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-        owner: root:root
-        path: /tmp/set_runc.sh
-        permissions: "0744"
       joinConfiguration:
         nodeRegistration:
           name: "{{ ds.meta_data.local_hostname }}"
           kubeletExtraArgs:
             cloud-provider: external
             provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-      preKubeadmCommands:
-        - sh /tmp/set_runc.sh
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment

--- a/example/cluster-machine-template-simple-taint.yaml
+++ b/example/cluster-machine-template-simple-taint.yaml
@@ -108,24 +108,12 @@ metadata:
 spec:
   template:
     spec:
-      files:
-      - content: |
-          #!/bin/sh
-
-          curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-          chmod +x /tmp/runc.amd64
-          cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-        owner: root:root
-        path: /tmp/set_runc.sh
-        permissions: "0744"
       joinConfiguration:
         nodeRegistration:
           name: "{{ ds.meta_data.local_hostname }}"
           kubeletExtraArgs:
             cloud-provider: external
             provider-id: aws://'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-      preKubeadmCommands:
-        - sh /tmp/set_runc.sh
 ---
 kind: KubeadmControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -150,15 +138,6 @@ spec:
           cloud-provider: external
           provider-id: aws://'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
         name: '{{ ds.meta_data.local_hostname }}'
-    files:
-    - content: |
-        #!/bin/sh
-        curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-        chmod +x /tmp/runc.amd64
-        cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-      owner: root:root
-      path: /tmp/set_runc.sh
-      permissions: "0744"
     joinConfiguration:
       nodeRegistration:
         taints:
@@ -168,6 +147,4 @@ spec:
         kubeletExtraArgs:
           cloud-provider: external
           provider-id: aws://'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-    preKubeadmCommands:
-      - sh /tmp/set_runc.sh
   version: "1.29.1"

--- a/example/cluster-machine-template-simple.yaml
+++ b/example/cluster-machine-template-simple.yaml
@@ -118,24 +118,12 @@ metadata:
 spec:
   template:
     spec:
-      files:
-      - content: |
-          #!/bin/sh
-
-          curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-          chmod +x /tmp/runc.amd64
-          cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-        owner: root:root
-        path: /tmp/set_runc.sh
-        permissions: "0744"
       joinConfiguration:
         nodeRegistration:
           name: "{{ ds.meta_data.local_hostname }}"
           kubeletExtraArgs:
             cloud-provider: external
             provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-      preKubeadmCommands:
-        - sh /tmp/set_runc.sh
 ---
 kind: KubeadmControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -158,21 +146,10 @@ spec:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
         name: '{{ ds.meta_data.local_hostname }}'
-    files:
-    - content: |
-        #!/bin/sh
-        curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-        chmod +x /tmp/runc.amd64
-        cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-      owner: root:root
-      path: /tmp/set_runc.sh
-      permissions: "0744"
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
         name: '{{ ds.meta_data.local_hostname }}'
-    preKubeadmCommands:
-      - sh /tmp/set_runc.sh
   version: "1.29.1"

--- a/example/hello-osc.yaml
+++ b/example/hello-osc.yaml
@@ -121,24 +121,12 @@ metadata:
 spec:
   template:
     spec:
-      files:
-        - content: |
-            #!/bin/sh
-
-            curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-            chmod +x /tmp/runc.amd64
-            cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-          owner: root:root
-          path: /tmp/set_runc.sh
-          permissions: "0744"
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
             cloud-provider: external
             provider-id: aws://'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
           name: '{{ ds.meta_data.local_hostname }}'
-      preKubeadmCommands:
-        - sh /tmp/set_runc.sh
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
@@ -147,16 +135,6 @@ metadata:
   namespace: default
 spec:
   kubeadmConfigSpec:
-    files:
-      - content: |
-          #!/bin/sh
-
-          curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-          chmod +x /tmp/runc.amd64
-          cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-        owner: root:root
-        path: /tmp/set_runc.sh
-        permissions: "0744"
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
@@ -168,8 +146,6 @@ spec:
         kubeletExtraArgs:
           cloud-provider: external
           provider-id: aws://'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-    preKubeadmCommands:
-      - sh /tmp/set_runc.sh
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/templates/cluster-template-multiaz-secure.yaml
+++ b/templates/cluster-template-multiaz-secure.yaml
@@ -191,24 +191,12 @@ metadata:
 spec:
   template:
     spec:
-      files:
-      - content: |
-          #!/bin/sh
-
-          curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-          chmod +x /tmp/runc.amd64
-          cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-        owner: root:root
-        path: /tmp/set_runc.sh
-        permissions: "0744"
       joinConfiguration:
         nodeRegistration:
           name: "{{ ds.meta_data.local_hostname }}"
           kubeletExtraArgs:
             cloud-provider: external
             provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-      preKubeadmCommands:
-      - sh /tmp/set_runc.sh
 ---
 kind: KubeadmControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -231,21 +219,9 @@ spec:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
         name: '{{ ds.meta_data.local_hostname }}'
-    files:
-    - content: |
-        #!/bin/sh
-
-        curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-        chmod +x /tmp/runc.amd64
-        cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-      owner: root:root
-      path: /tmp/set_runc.sh
-      permissions: "0744"
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-    preKubeadmCommands:
-    - sh /tmp/set_runc.sh
   version: "${KUBERNETES_VERSION}"

--- a/templates/cluster-template-multiaz.yaml
+++ b/templates/cluster-template-multiaz.yaml
@@ -186,24 +186,12 @@ metadata:
 spec:
   template:
     spec:
-      files:
-      - content: |
-          #!/bin/sh
-
-          curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-          chmod +x /tmp/runc.amd64
-          cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-        owner: root:root
-        path: /tmp/set_runc.sh
-        permissions: "0744"
       joinConfiguration:
         nodeRegistration:
           name: "{{ ds.meta_data.local_hostname }}"
           kubeletExtraArgs:
             cloud-provider: external
             provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-      preKubeadmCommands:
-      - sh /tmp/set_runc.sh
 ---
 kind: KubeadmControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -226,21 +214,9 @@ spec:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
         name: '{{ ds.meta_data.local_hostname }}'
-    files:
-    - content: |
-        #!/bin/sh
-
-        curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-        chmod +x /tmp/runc.amd64
-        cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-      owner: root:root
-      path: /tmp/set_runc.sh
-      permissions: "0744"
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-    preKubeadmCommands:
-    - sh /tmp/set_runc.sh
   version: "${KUBERNETES_VERSION}"

--- a/templates/cluster-template-secure-opensource.yaml
+++ b/templates/cluster-template-secure-opensource.yaml
@@ -103,24 +103,12 @@ metadata:
 spec:
   template:
     spec:
-      files:
-      - content: |
-          #!/bin/sh
-
-          curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-          chmod +x /tmp/runc.amd64
-          cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-        owner: root:root
-        path: /tmp/set_runc.sh
-        permissions: "0744"
       joinConfiguration:
         nodeRegistration:
           name: "{{ ds.meta_data.local_hostname }}"
           kubeletExtraArgs:
             cloud-provider: external
             provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-      preKubeadmCommands:
-      - sh /tmp/set_runc.sh
 ---
 kind: KubeadmControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -143,21 +131,9 @@ spec:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
         name: '{{ ds.meta_data.local_hostname }}'
-    files:
-    - content: |
-        #!/bin/sh
-
-        curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-        chmod +x /tmp/runc.amd64
-        cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-      owner: root:root
-      path: /tmp/set_runc.sh
-      permissions: "0744"
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-    preKubeadmCommands:
-    - sh /tmp/set_runc.sh
   version: "${KUBERNETES_VERSION}"

--- a/templates/cluster-template-secure.yaml
+++ b/templates/cluster-template-secure.yaml
@@ -103,24 +103,12 @@ metadata:
 spec:
   template:
     spec:
-      files:
-      - content: |
-          #!/bin/sh
-
-          curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-          chmod +x /tmp/runc.amd64
-          cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-        owner: root:root
-        path: /tmp/set_runc.sh
-        permissions: "0744"
       joinConfiguration:
         nodeRegistration:
           name: "{{ ds.meta_data.local_hostname }}"
           kubeletExtraArgs:
             cloud-provider: external
             provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-      preKubeadmCommands:
-      - sh /tmp/set_runc.sh
 ---
 kind: KubeadmControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -143,21 +131,9 @@ spec:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
         name: '{{ ds.meta_data.local_hostname }}'
-    files:
-    - content: |
-        #!/bin/sh
-
-        curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-        chmod +x /tmp/runc.amd64
-        cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-      owner: root:root
-      path: /tmp/set_runc.sh
-      permissions: "0744"
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-    preKubeadmCommands:
-    - sh /tmp/set_runc.sh
   version: "${KUBERNETES_VERSION}"

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -98,24 +98,12 @@ metadata:
 spec:
   template:
     spec:
-      files:
-      - content: |
-          #!/bin/sh
-
-          curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-          chmod +x /tmp/runc.amd64
-          cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-        owner: root:root
-        path: /tmp/set_runc.sh
-        permissions: "0744"
       joinConfiguration:
         nodeRegistration:
           name: "{{ ds.meta_data.local_hostname }}"
           kubeletExtraArgs:
             cloud-provider: external
             provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-      preKubeadmCommands:
-      - sh /tmp/set_runc.sh
 ---
 kind: KubeadmControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -138,21 +126,9 @@ spec:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
         name: '{{ ds.meta_data.local_hostname }}'
-    files:
-    - content: |
-        #!/bin/sh
-
-        curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-        chmod +x /tmp/runc.amd64
-        cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-      owner: root:root
-      path: /tmp/set_runc.sh
-      permissions: "0744"
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-    preKubeadmCommands:
-    - sh /tmp/set_runc.sh
   version: "${KUBERNETES_VERSION}"

--- a/test/e2e/data/infrastructure-outscale/cluster-template-kcp-remediation.yaml
+++ b/test/e2e/data/infrastructure-outscale/cluster-template-kcp-remediation.yaml
@@ -101,24 +101,12 @@ metadata:
 spec:
   template:
     spec:
-      files:
-        - content: |
-            #!/bin/sh
-
-            curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-            chmod +x /tmp/runc.amd64
-            cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-          owner: root:root
-          path: /tmp/set_runc.sh
-          permissions: "0744"
       joinConfiguration:
         nodeRegistration:
           name: "{{ ds.meta_data.local_hostname }}"
           kubeletExtraArgs:
             cloud-provider: external
             provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-      preKubeadmCommands:
-        - sh /tmp/set_runc.sh
 ---
 kind: KubeadmControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -138,23 +126,11 @@ spec:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
         name: '{{ ds.meta_data.local_hostname }}'
-    files:
-      - content: |
-          #!/bin/sh
-
-          curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-          chmod +x /tmp/runc.amd64
-          cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-        owner: root:root
-        path: /tmp/set_runc.sh
-        permissions: "0744"
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}' 
-    preKubeadmCommands:
-      - sh /tmp/set_runc.sh
   version: "${KUBERNETES_VERSION}"
 ---
 apiVersion: v1

--- a/test/e2e/data/infrastructure-outscale/cluster-template-md-remediation.yaml
+++ b/test/e2e/data/infrastructure-outscale/cluster-template-md-remediation.yaml
@@ -102,24 +102,12 @@ metadata:
 spec:
   template:
     spec:
-      files:
-        - content: |
-            #!/bin/sh
-
-            curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-            chmod +x /tmp/runc.amd64
-            cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-          owner: root:root
-          path: /tmp/set_runc.sh
-          permissions: "0744"
       joinConfiguration:
         nodeRegistration:
           name: "{{ ds.meta_data.local_hostname }}"
           kubeletExtraArgs:
             cloud-provider: external
             provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-      preKubeadmCommands:
-        - sh /tmp/set_runc.sh
 ---
 kind: KubeadmControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -139,23 +127,11 @@ spec:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
         name: '{{ ds.meta_data.local_hostname }}'
-    files:
-      - content: |
-          #!/bin/sh
-
-          curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-          chmod +x /tmp/runc.amd64
-          cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-        owner: root:root
-        path: /tmp/set_runc.sh
-        permissions: "0744"
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-    preKubeadmCommands:
-      - sh /tmp/set_runc.sh
   version: "${KUBERNETES_VERSION}"
 ---
 apiVersion: v1

--- a/test/e2e/data/infrastructure-outscale/cluster-template-multiaz.yaml
+++ b/test/e2e/data/infrastructure-outscale/cluster-template-multiaz.yaml
@@ -170,24 +170,12 @@ metadata:
 spec:
   template:
     spec:
-      files:
-        - content: |
-            #!/bin/sh
-
-            curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-            chmod +x /tmp/runc.amd64
-            cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-          owner: root:root
-          path: /tmp/set_runc.sh
-          permissions: "0744"
       joinConfiguration:
         nodeRegistration:
           name: "{{ ds.meta_data.local_hostname }}"
           kubeletExtraArgs:
             cloud-provider: external
             provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-      preKubeadmCommands:
-        - sh /tmp/set_runc.sh
 ---
 kind: KubeadmControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -207,23 +195,11 @@ spec:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
         name: '{{ ds.meta_data.local_hostname }}'
-    files:
-      - content: |
-          #!/bin/sh
-
-          curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-          chmod +x /tmp/runc.amd64
-          cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-        owner: root:root
-        path: /tmp/set_runc.sh
-        permissions: "0744"
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-    preKubeadmCommands:
-      - sh /tmp/set_runc.sh
   version: "${KUBERNETES_VERSION}"
 ---
 apiVersion: v1

--- a/test/e2e/data/infrastructure-outscale/cluster-template-node-drain.yaml
+++ b/test/e2e/data/infrastructure-outscale/cluster-template-node-drain.yaml
@@ -102,24 +102,12 @@ metadata:
 spec:
   template:
     spec:
-      files:
-        - content: |
-            #!/bin/sh
-
-            curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-            chmod +x /tmp/runc.amd64
-            cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-          owner: root:root
-          path: /tmp/set_runc.sh
-          permissions: "0744"
       joinConfiguration:
         nodeRegistration:
           name: "{{ ds.meta_data.local_hostname }}"
           kubeletExtraArgs:
             cloud-provider: external
             provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}' 
-      preKubeadmCommands:
-        - sh /tmp/set_runc.sh
 ---
 kind: KubeadmControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -140,23 +128,11 @@ spec:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
         name: '{{ ds.meta_data.local_hostname }}'
-    files:
-      - content: |
-          #!/bin/sh
-
-          curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-          chmod +x /tmp/runc.amd64
-          cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-        owner: root:root
-        path: /tmp/set_runc.sh
-        permissions: "0744"
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-    preKubeadmCommands:
-      - sh /tmp/set_runc.sh
   version: "${KUBERNETES_VERSION}"
 ---
 apiVersion: v1

--- a/test/e2e/data/infrastructure-outscale/cluster-template-public.yaml
+++ b/test/e2e/data/infrastructure-outscale/cluster-template-public.yaml
@@ -102,24 +102,12 @@ metadata:
 spec:
   template:
     spec:
-      files:
-        - content: |
-            #!/bin/sh
-
-            curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-            chmod +x /tmp/runc.amd64
-            cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-          owner: root:root
-          path: /tmp/set_runc.sh
-          permissions: "0744"
       joinConfiguration:
         nodeRegistration:
           name: "{{ ds.meta_data.local_hostname }}"
           kubeletExtraArgs:
             cloud-provider: external
             provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-      preKubeadmCommands:
-        - sh /tmp/set_runc.sh
 ---
 kind: KubeadmControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -139,23 +127,11 @@ spec:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
         name: '{{ ds.meta_data.local_hostname }}'
-    files:
-      - content: |
-          #!/bin/sh
-
-          curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-          chmod +x /tmp/runc.amd64
-          cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-        owner: root:root
-        path: /tmp/set_runc.sh
-        permissions: "0744"
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-    preKubeadmCommands:
-      - sh /tmp/set_runc.sh
   version: "${KUBERNETES_VERSION}"
 ---
 apiVersion: v1

--- a/test/e2e/data/infrastructure-outscale/cluster-template-upgrade-scale-in.yaml
+++ b/test/e2e/data/infrastructure-outscale/cluster-template-upgrade-scale-in.yaml
@@ -155,24 +155,12 @@ metadata:
 spec:
   template:
     spec:
-      files:
-        - content: |
-            #!/bin/sh
-
-            curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-            chmod +x /tmp/runc.amd64
-            cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-          owner: root:root
-          path: /tmp/set_runc.sh
-          permissions: "0744"
       joinConfiguration:
         nodeRegistration:
           name: "{{ ds.meta_data.local_hostname }}"
           kubeletExtraArgs:
             cloud-provider: external
             provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-      preKubeadmCommands:
-        - sh /tmp/set_runc.sh
 ---
 kind: KubeadmControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -195,23 +183,11 @@ spec:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
         name: '{{ ds.meta_data.local_hostname }}'
-    files:
-      - content: |
-          #!/bin/sh
-
-          curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-          chmod +x /tmp/runc.amd64
-          cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-        owner: root:root
-        path: /tmp/set_runc.sh
-        permissions: "0744"
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-    preKubeadmCommands:
-      - sh /tmp/set_runc.sh
   version: "${KUBERNETES_VERSION}"
 ---
 apiVersion: v1

--- a/test/e2e/data/infrastructure-outscale/cluster-template-upgrades.yaml
+++ b/test/e2e/data/infrastructure-outscale/cluster-template-upgrades.yaml
@@ -144,24 +144,12 @@ metadata:
 spec:
   template:
     spec:
-      files:
-        - content: |
-            #!/bin/sh
-
-            curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-            chmod +x /tmp/runc.amd64
-            cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-          owner: root:root
-          path: /tmp/set_runc.sh
-          permissions: "0744"
       joinConfiguration:
         nodeRegistration:
           name: "{{ ds.meta_data.local_hostname }}"
           kubeletExtraArgs:
             cloud-provider: external
             provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-      preKubeadmCommands:
-        - sh /tmp/set_runc.sh
 ---
 kind: KubeadmControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -181,23 +169,11 @@ spec:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
         name: '{{ ds.meta_data.local_hostname }}'
-    files:
-      - content: |
-          #!/bin/sh
-
-          curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-          chmod +x /tmp/runc.amd64
-          cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-        owner: root:root
-        path: /tmp/set_runc.sh
-        permissions: "0744"
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-    preKubeadmCommands:
-      - sh /tmp/set_runc.sh
   version: "${KUBERNETES_VERSION}"
 ---
 apiVersion: v1

--- a/test/e2e/data/infrastructure-outscale/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-outscale/cluster-template.yaml
@@ -101,24 +101,12 @@ metadata:
 spec:
   template:
     spec:
-      files:
-        - content: |
-            #!/bin/sh
-
-            curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-            chmod +x /tmp/runc.amd64
-            cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-          owner: root:root
-          path: /tmp/set_runc.sh
-          permissions: "0744"
       joinConfiguration:
         nodeRegistration:
           name: "{{ ds.meta_data.local_hostname }}"
           kubeletExtraArgs:
             cloud-provider: external
             provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-      preKubeadmCommands:
-        - sh /tmp/set_runc.sh
 ---
 kind: KubeadmControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -138,23 +126,11 @@ spec:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
         name: '{{ ds.meta_data.local_hostname }}'
-    files:
-      - content: |
-          #!/bin/sh
-
-          curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-          chmod +x /tmp/runc.amd64
-          cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-        owner: root:root
-        path: /tmp/set_runc.sh
-        permissions: "0744"
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
           provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-    preKubeadmCommands:
-      - sh /tmp/set_runc.sh
   version: "${KUBERNETES_VERSION}"
 ---
 apiVersion: v1

--- a/test/e2e/data/infrastructure-outscale/clusterclass-cluster-class.yaml
+++ b/test/e2e/data/infrastructure-outscale/clusterclass-cluster-class.yaml
@@ -165,24 +165,12 @@ metadata:
 spec:
   template:
     spec:
-      files:
-        - content: |
-            #!/bin/sh
-
-            curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-            chmod +x /tmp/runc.amd64
-            cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-          owner: root:root
-          path: /tmp/set_runc.sh
-          permissions: "0744"
       joinConfiguration:
         nodeRegistration:
           name: "{{ ds.meta_data.local_hostname }}"
           kubeletExtraArgs:
             cloud-provider: external
             provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-      preKubeadmCommands:
-        - sh /tmp/set_runc.sh
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlaneTemplate
@@ -205,21 +193,9 @@ spec:
             kubeletExtraArgs:
               cloud-provider: external
               provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-        files:
-          - content: |
-              #!/bin/sh
-
-              curl https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64 -Lo /tmp/runc.amd64
-              chmod +x /tmp/runc.amd64
-              cp -f /tmp/runc.amd64 /usr/local/sbin/runc
-            owner: root:root
-            path: /tmp/set_runc.sh
-            permissions: "0744"
         joinConfiguration:
           nodeRegistration:
             name: "{{ ds.meta_data.local_hostname }}"
             kubeletExtraArgs:
               cloud-provider: external
               provider-id: aws:///'{{ ds.meta_data.placement.availability_zone }}'/'{{ ds.meta_data.instance_id }}'
-        preKubeadmCommands:
-          - sh /tmp/set_runc.sh


### PR DESCRIPTION
## Description

The Kubeadm templates installed runc on nodes. As image-builder already installs runc in OMIs, no need to install it again.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [x] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
