### PR TITLE
⚡️ perfs: add concurrency + tuning config flags

### DIFF
--- a/controllers/osccluster_controller.go
+++ b/controllers/osccluster_controller.go
@@ -25,6 +25,7 @@ import (
 	predicates "sigs.k8s.io/cluster-api/util/predicates"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -285,8 +286,9 @@ func (r *OscClusterReconciler) reconcileDelete(ctx context.Context, clusterScope
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *OscClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+func (r *OscClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(options).
 		For(&infrastructurev1beta1.OscCluster{}).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(mgr.GetScheme(), ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
 		Complete(r)

--- a/controllers/oscmachine_controller.go
+++ b/controllers/oscmachine_controller.go
@@ -204,6 +204,7 @@ func (r *OscMachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Ma
 		return fmt.Errorf("failed to create mapper for Cluster to OscMachines: %w", err)
 	}
 	err = ctrl.NewControllerManagedBy(mgr).
+		WithOptions(options).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(mgr.GetScheme(), ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
 		For(&infrastructurev1beta1.OscMachine{}).
 		Watches(


### PR DESCRIPTION
## Description

CAPOSC now processes multiple OscCluster/OscMachine resources simultaneously.

The PR also adds many new configuration flags:
* `--leader-elect-lease-duration`: Interval at which non-leader candidates will wait to force acquire leadership (previous default: 60s, new default: 15s)
* `--leader-elect-renew-deadline`: Duration that the leading controller manager will retry refreshing leadership before giving up (previous default: 30s, new default: 10s)
* `--leader-elect-retry-period`: Duration that the leading controller manager will retry refreshing leadership before giving up (previous default: 10s, new default: 2s)
* `--reconcile-timeout`: Timeout for reconciles (default: 90m, not changed)
* `--osccluster-concurrency`: Number of OscCluster reconciles to process simultaneously (previous default: 1, new default: 2)
* `--oscmachine-concurrency`: Number of OscMachine reconciles to process simultaneously (previous default: 1, new default: 2)

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [x] Other (specify): performance

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
