### PR TITLE
🐛 fix(webhooks): OscMachineTemplate immutability should not be enforced during topology dry-runs (port)

### DIFF
--- a/api/v1beta1/oscclustertemplate_webhook_test.go
+++ b/api/v1beta1/oscclustertemplate_webhook_test.go
@@ -6,13 +6,13 @@ SPDX-License-Identifier: BSD-3-Clause
 package v1beta1_test
 
 import (
-	"context"
 	"errors"
 	"testing"
 
 	infrastructurev1beta1 "github.com/outscale/cluster-api-provider-outscale/api/v1beta1"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // TestOscClusterTemplate_ValidateCreate check good and bad validation of oscCluster spec
@@ -37,8 +37,9 @@ func TestOscClusterTemplate_ValidateCreate(t *testing.T) {
 	h := infrastructurev1beta1.OscClusterTemplateWebhook{}
 	for _, ctc := range clusterTestCases {
 		t.Run(ctc.name, func(t *testing.T) {
+			ctx := admission.NewContextWithRequest(t.Context(), admission.Request{})
 			oscInfraClusterTemplate := createOscInfraClusterTemplate(ctc.clusterSpec, "webhook-test", "default")
-			_, err := h.ValidateCreate(context.TODO(), oscInfraClusterTemplate)
+			_, err := h.ValidateCreate(ctx, oscInfraClusterTemplate)
 			if ctc.expValidateCreateErr != nil {
 				require.EqualError(t, err, ctc.expValidateCreateErr.Error(), "ValidateCreate() should return the same error")
 			} else {

--- a/api/v1beta1/oscmachinetemplate_webhook.go
+++ b/api/v1beta1/oscmachinetemplate_webhook.go
@@ -14,6 +14,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/cluster-api/util/topology"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -57,12 +58,21 @@ func (OscMachineTemplateWebhook) ValidateCreate(_ context.Context, obj runtime.O
 }
 
 // ValidateUpdate implements webhook.CustomValidator.
-func (OscMachineTemplateWebhook) ValidateUpdate(_ context.Context, obj runtime.Object, oldRaw runtime.Object) (admission.Warnings, error) {
+func (OscMachineTemplateWebhook) ValidateUpdate(ctx context.Context, obj runtime.Object, oldRaw runtime.Object) (admission.Warnings, error) {
 	r, ok := obj.(*OscMachineTemplate)
 	if !ok {
 		return nil, fmt.Errorf("expected an OscMachineTemplate object but got %T", r)
 	}
 	var allErrs field.ErrorList
+
+	req, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a admission.Request inside context: %v", err))
+	}
+	if topology.ShouldSkipImmutabilityChecks(req, r) {
+		return nil, nil
+	}
+
 	old := oldRaw.(*OscMachineTemplate)
 	if !reflect.DeepEqual(r.Spec.Template.Spec, old.Spec.Template.Spec) {
 		allErrs = append(allErrs,

--- a/api/v1beta1/oscmachinetemplate_webhook_test.go
+++ b/api/v1beta1/oscmachinetemplate_webhook_test.go
@@ -7,13 +7,13 @@ SPDX-License-Identifier: Apache-2.0
 package v1beta1_test
 
 import (
-	"context"
 	"testing"
 
 	infrastructurev1beta1 "github.com/outscale/cluster-api-provider-outscale/api/v1beta1"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // TestOscMachineTemplate_ValidateCreate check good and bad update of oscMachineTemplate
@@ -263,8 +263,9 @@ func TestOscMachineTemplate_ValidateCreate(t *testing.T) {
 	h := infrastructurev1beta1.OscMachineTemplateWebhook{}
 	for _, mtc := range machineTestCases {
 		t.Run(mtc.name, func(t *testing.T) {
+			ctx := admission.NewContextWithRequest(t.Context(), admission.Request{})
 			oscInfraMachineTemplate := createOscInfraMachineTemplate(mtc.machineSpec, "webhook-test", "default")
-			_, err := h.ValidateCreate(context.TODO(), oscInfraMachineTemplate)
+			_, err := h.ValidateCreate(ctx, oscInfraMachineTemplate)
 			if mtc.errorCount > 0 {
 				require.Error(t, err, "ValidateCreate should return the same errror")
 				require.Len(t, err.(*apierrors.StatusError).Status().Details.Causes, mtc.errorCount)
@@ -347,9 +348,10 @@ func TestOscMachineTemplate_ValidateUpdate(t *testing.T) {
 	h := infrastructurev1beta1.OscMachineTemplateWebhook{}
 	for _, mtc := range machineTestCases {
 		t.Run(mtc.name, func(t *testing.T) {
+			ctx := admission.NewContextWithRequest(t.Context(), admission.Request{})
 			oscOldInfraMachineTemplate := createOscInfraMachineTemplate(mtc.oldMachineSpec, "old-webhook-test", "default")
 			oscInfraMachineTemplate := createOscInfraMachineTemplate(mtc.machineSpec, "webhook-test", "default")
-			_, err := h.ValidateUpdate(context.TODO(), oscInfraMachineTemplate, oscOldInfraMachineTemplate)
+			_, err := h.ValidateUpdate(ctx, oscInfraMachineTemplate, oscOldInfraMachineTemplate)
 			if mtc.hasError {
 				require.Error(t, err)
 			} else {


### PR DESCRIPTION
This PR is a port of #865 to main.

> Note: validation is not yet implemented in the v1beta2 schema