### PR TITLE
🐛 fix(webhooks): fix param order

### DIFF
--- a/.github/workflows/unit-quickstart-e2e-test.yaml
+++ b/.github/workflows/unit-quickstart-e2e-test.yaml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, v1.x ]
     paths:
       - ".github/workflows/unit-quickstart-e2e-test.yaml"
       - "github_actions/deploy_cluster/**"

--- a/api/v1beta1/osccluster_webhook.go
+++ b/api/v1beta1/osccluster_webhook.go
@@ -55,31 +55,31 @@ func (OscClusterWebhook) ValidateCreate(_ context.Context, obj runtime.Object) (
 }
 
 // ValidateUpdate implements webhook.CustomValidator.
-func (OscClusterWebhook) ValidateUpdate(_ context.Context, obj runtime.Object, oldRaw runtime.Object) (admission.Warnings, error) {
-	r, ok := obj.(*OscCluster)
+func (OscClusterWebhook) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	oldC, ok := oldObj.(*OscCluster)
 	if !ok {
-		return nil, fmt.Errorf("expected an OscCluster object but got %T", r)
+		return nil, fmt.Errorf("expected an OscCluster object but got %T", oldC)
 	}
 	var allErrs field.ErrorList
-	old := oldRaw.(*OscCluster)
-	if !slices.Contains(r.Spec.Network.Disable, DisableLB) {
-		if r.Spec.Network.LoadBalancer.LoadBalancerName != old.Spec.Network.LoadBalancer.LoadBalancerName {
+	newC := newObj.(*OscCluster)
+	if !slices.Contains(oldC.Spec.Network.Disable, DisableLB) {
+		if newC.Spec.Network.LoadBalancer.LoadBalancerName != oldC.Spec.Network.LoadBalancer.LoadBalancerName {
 			allErrs = append(allErrs,
 				field.Invalid(field.NewPath("network", "loadBalancer", "loadbalancername"),
-					r.Spec.Network.LoadBalancer.LoadBalancerName, "field is immutable"),
+					newC.Spec.Network.LoadBalancer.LoadBalancerName, "field is immutable"),
 			)
 		}
-		if r.Spec.Network.LoadBalancer.LoadBalancerType != old.Spec.Network.LoadBalancer.LoadBalancerType {
+		if newC.Spec.Network.LoadBalancer.LoadBalancerType != oldC.Spec.Network.LoadBalancer.LoadBalancerType {
 			allErrs = append(allErrs,
 				field.Invalid(field.NewPath("network", "loadBalancer", "loadbalancertype"),
-					r.Spec.Network.LoadBalancer.LoadBalancerType, "field is immutable"),
+					newC.Spec.Network.LoadBalancer.LoadBalancerType, "field is immutable"),
 			)
 		}
 	}
 	if len(allErrs) == 0 {
 		return nil, nil
 	}
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind("OscCluster").GroupKind(), r.Name, allErrs)
+	return nil, apierrors.NewInvalid(GroupVersion.WithKind("OscCluster").GroupKind(), newC.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.CustomValidator.

--- a/api/v1beta1/oscclustertemplate_webhook.go
+++ b/api/v1beta1/oscclustertemplate_webhook.go
@@ -57,22 +57,22 @@ func (OscClusterTemplateWebhook) ValidateCreate(_ context.Context, obj runtime.O
 }
 
 // ValidateUpdate implements webhook.CustomValidator.
-func (OscClusterTemplateWebhook) ValidateUpdate(_ context.Context, obj runtime.Object, oldRaw runtime.Object) (admission.Warnings, error) {
-	r, ok := obj.(*OscClusterTemplate)
+func (OscClusterTemplateWebhook) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	oldC, ok := oldObj.(*OscClusterTemplate)
 	if !ok {
-		return nil, fmt.Errorf("expected an OscClusterTemplate object but got %T", r)
+		return nil, fmt.Errorf("expected an OscClusterTemplate object but got %T", oldC)
 	}
 	var allErrs field.ErrorList
-	old := oldRaw.(*OscClusterTemplate)
-	if !reflect.DeepEqual(r.Spec.Template.Spec, old.Spec.Template.Spec) {
+	newC := newObj.(*OscClusterTemplate)
+	if !reflect.DeepEqual(newC.Spec.Template.Spec, oldC.Spec.Template.Spec) {
 		allErrs = append(allErrs,
-			field.Invalid(field.NewPath("template", "spec"), r, "spec is immutable."),
+			field.Invalid(field.NewPath("template", "spec"), newC, "spec is immutable."),
 		)
 	}
 	if len(allErrs) == 0 {
 		return nil, nil
 	}
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind("OscClusterTemmplate").GroupKind(), r.Name, allErrs)
+	return nil, apierrors.NewInvalid(GroupVersion.WithKind("OscClusterTemmplate").GroupKind(), newC.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.CustomValidator.

--- a/api/v1beta1/oscmachine_webhook.go
+++ b/api/v1beta1/oscmachine_webhook.go
@@ -56,73 +56,73 @@ func (OscMachineWebhook) ValidateCreate(_ context.Context, obj runtime.Object) (
 }
 
 // ValidateUpdate implements webhook.CustomValidator.
-func (OscMachineWebhook) ValidateUpdate(_ context.Context, obj runtime.Object, oldRaw runtime.Object) (admission.Warnings, error) {
-	r, ok := obj.(*OscMachine)
+func (OscMachineWebhook) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	oldM, ok := oldObj.(*OscMachine)
 	if !ok {
-		return nil, fmt.Errorf("expected an OscMachine object but got %T", r)
+		return nil, fmt.Errorf("expected an OscMachine object but got %T", oldM)
 	}
 	var allErrs field.ErrorList
-	old := oldRaw.(*OscMachine)
+	newM := newObj.(*OscMachine)
 
-	if r.Spec.Node.Vm.VmType != old.Spec.Node.Vm.VmType {
+	if newM.Spec.Node.Vm.VmType != oldM.Spec.Node.Vm.VmType {
 		allErrs = append(allErrs,
 			field.Invalid(field.NewPath("node", "vm", "vmType"),
-				r.Spec.Node.Vm.VmType, "field is immutable"),
+				newM.Spec.Node.Vm.VmType, "field is immutable"),
 		)
 	}
 
-	if r.Spec.Node.Vm.KeypairName != old.Spec.Node.Vm.KeypairName {
+	if newM.Spec.Node.Vm.KeypairName != oldM.Spec.Node.Vm.KeypairName {
 		allErrs = append(allErrs,
 			field.Invalid(field.NewPath("node", "vm", "keyPairName"),
-				r.Spec.Node.Vm.KeypairName, "field is immutable"),
+				newM.Spec.Node.Vm.KeypairName, "field is immutable"),
 		)
 	}
 
-	if old.Spec.Node.Vm.SubregionName != "" && r.Spec.Node.Vm.SubregionName != old.Spec.Node.Vm.SubregionName {
+	if oldM.Spec.Node.Vm.SubregionName != "" && newM.Spec.Node.Vm.SubregionName != oldM.Spec.Node.Vm.SubregionName {
 		allErrs = append(allErrs,
 			field.Invalid(field.NewPath("node", "vm", "subregionName"),
-				r.Spec.Node.Vm.SubregionName, "field is immutable"),
+				newM.Spec.Node.Vm.SubregionName, "field is immutable"),
 		)
 	}
 
-	if len(old.Spec.Node.Vm.Tags) > 0 && !maps.Equal(r.Spec.Node.Vm.Tags, old.Spec.Node.Vm.Tags) {
+	if len(oldM.Spec.Node.Vm.Tags) > 0 && !maps.Equal(newM.Spec.Node.Vm.Tags, oldM.Spec.Node.Vm.Tags) {
 		allErrs = append(allErrs,
 			field.Invalid(field.NewPath("node", "vm", "tags"),
-				r.Spec.Node.Vm.Tags, "field is immutable"),
+				newM.Spec.Node.Vm.Tags, "field is immutable"),
 		)
 	}
 
-	if (old.Spec.Node.Vm.SubnetName != "") && r.Spec.Node.Vm.SubnetName != old.Spec.Node.Vm.SubnetName {
+	if oldM.Spec.Node.Vm.SubnetName != "" && newM.Spec.Node.Vm.SubnetName != oldM.Spec.Node.Vm.SubnetName {
 		allErrs = append(allErrs,
 			field.Invalid(field.NewPath("node", "vm", "subnetName"),
-				r.Spec.Node.Vm.SubnetName, "field is immutable"),
+				newM.Spec.Node.Vm.SubnetName, "field is immutable"),
 		)
 	}
-	if r.Spec.Node.Vm.RootDisk.RootDiskSize != old.Spec.Node.Vm.RootDisk.RootDiskSize {
+	if newM.Spec.Node.Vm.RootDisk.RootDiskSize != oldM.Spec.Node.Vm.RootDisk.RootDiskSize {
 		allErrs = append(allErrs,
 			field.Invalid(field.NewPath("node", "vm", "rootDisk", "rootDiskSize"),
-				r.Spec.Node.Vm.RootDisk.RootDiskSize, "field is immutable"),
+				newM.Spec.Node.Vm.RootDisk.RootDiskSize, "field is immutable"),
 		)
 	}
 
-	if r.Spec.Node.Vm.RootDisk.RootDiskIops != old.Spec.Node.Vm.RootDisk.RootDiskIops {
+	if newM.Spec.Node.Vm.RootDisk.RootDiskIops != oldM.Spec.Node.Vm.RootDisk.RootDiskIops {
 		allErrs = append(allErrs,
 			field.Invalid(field.NewPath("node", "vm", "rootDisk", "rootDiskIops"),
-				r.Spec.Node.Vm.RootDisk.RootDiskIops, "field is immutable"),
+				newM.Spec.Node.Vm.RootDisk.RootDiskIops, "field is immutable"),
 		)
 	}
 
-	if r.Spec.Node.Vm.RootDisk.RootDiskType != old.Spec.Node.Vm.RootDisk.RootDiskType {
+	if newM.Spec.Node.Vm.RootDisk.RootDiskType != oldM.Spec.Node.Vm.RootDisk.RootDiskType {
 		allErrs = append(allErrs,
 			field.Invalid(field.NewPath("node", "vm", "rootDisk", "rootDiskType"),
-				r.Spec.Node.Vm.RootDisk.RootDiskType, "field is immutable"),
+				newM.Spec.Node.Vm.RootDisk.RootDiskType, "field is immutable"),
 		)
 	}
 
 	if len(allErrs) == 0 {
 		return nil, nil
 	}
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind("OscMachine").GroupKind(), r.Name, allErrs)
+	return nil, apierrors.NewInvalid(GroupVersion.WithKind("OscMachine").GroupKind(), newM.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.CustomValidator.

--- a/api/v1beta1/oscmachinetemplate_webhook.go
+++ b/api/v1beta1/oscmachinetemplate_webhook.go
@@ -58,10 +58,10 @@ func (OscMachineTemplateWebhook) ValidateCreate(_ context.Context, obj runtime.O
 }
 
 // ValidateUpdate implements webhook.CustomValidator.
-func (OscMachineTemplateWebhook) ValidateUpdate(ctx context.Context, obj runtime.Object, oldRaw runtime.Object) (admission.Warnings, error) {
-	r, ok := obj.(*OscMachineTemplate)
+func (OscMachineTemplateWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	oldM, ok := oldObj.(*OscMachineTemplate)
 	if !ok {
-		return nil, fmt.Errorf("expected an OscMachineTemplate object but got %T", r)
+		return nil, fmt.Errorf("expected an OscMachineTemplate object but got %T", oldM)
 	}
 	var allErrs field.ErrorList
 
@@ -69,20 +69,20 @@ func (OscMachineTemplateWebhook) ValidateUpdate(ctx context.Context, obj runtime
 	if err != nil {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a admission.Request inside context: %v", err))
 	}
-	if topology.ShouldSkipImmutabilityChecks(req, r) {
+
+	newM := newObj.(*OscMachineTemplate)
+	if topology.ShouldSkipImmutabilityChecks(req, newM) {
 		return nil, nil
 	}
-
-	old := oldRaw.(*OscMachineTemplate)
-	if !reflect.DeepEqual(r.Spec.Template.Spec, old.Spec.Template.Spec) {
+	if !reflect.DeepEqual(newM.Spec.Template.Spec, oldM.Spec.Template.Spec) {
 		allErrs = append(allErrs,
-			field.Invalid(field.NewPath("template", "spec"), r, "spec is immutable"),
+			field.Invalid(field.NewPath("template", "spec"), newM, "spec is immutable"),
 		)
 	}
 	if len(allErrs) == 0 {
 		return nil, nil
 	}
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind("OscMachineTemplate").GroupKind(), r.Name, allErrs)
+	return nil, apierrors.NewInvalid(GroupVersion.WithKind("OscMachineTemplate").GroupKind(), newM.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.CustomValidator.

--- a/api/v1beta1/oscmachinetemplate_webhook_test.go
+++ b/api/v1beta1/oscmachinetemplate_webhook_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // TestOscMachineTemplate_ValidateCreate check good and bad update of oscMachineTemplate
@@ -347,9 +348,10 @@ func TestOscMachineTemplate_ValidateUpdate(t *testing.T) {
 	h := infrastructurev1beta1.OscMachineTemplateWebhook{}
 	for _, mtc := range machineTestCases {
 		t.Run(mtc.name, func(t *testing.T) {
+			ctx := admission.NewContextWithRequest(t.Context(), admission.Request{})
 			oscOldInfraMachineTemplate := createOscInfraMachineTemplate(mtc.oldMachineSpec, "old-webhook-test", "default")
 			oscInfraMachineTemplate := createOscInfraMachineTemplate(mtc.machineSpec, "webhook-test", "default")
-			_, err := h.ValidateUpdate(context.TODO(), oscInfraMachineTemplate, oscOldInfraMachineTemplate)
+			_, err := h.ValidateUpdate(ctx, oscInfraMachineTemplate, oscOldInfraMachineTemplate)
 			if mtc.hasError {
 				require.Error(t, err)
 			} else {


### PR DESCRIPTION
## Description

This PR fixes the order of params in ValidateUpdate. This broke the MachineTemplate dry-run test.

Fixes: #895
Refs: #864 

## Type of Change

Please check the relevant option(s):

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
