### PR TITLE
👷 build: avoid dirty state for goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,10 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USER }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-    - name: generate artefacts
-      run: make release
+    - name: 🔨Generate artefacts
+      run: |
+        make release
+        git reset HEAD --hard
       env:
         IMG_RELEASE: outscale/cluster-api-outscale-controllers:${{ github.ref_name }}
         RELEASE_TAG: ${{ github.ref_name }}

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ test/e2e/config/*-envsubst.yaml
 test/e2e/data/ccm/ccm.yaml
 # Test binary, built with `go test -c`
 *.test
+__debug*
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 apicovers.txt
@@ -23,3 +24,5 @@ secret.*
 clusterctl-settings.json
 # Dependency directories (remove the comment below to include it)
 bin/
+dist/
+out/


### PR DESCRIPTION
## Description

The kustomize files were updated by the workflow, resulting in a dirty git state.

This PR resets the repository before calling goreleaser.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [x] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
